### PR TITLE
fix: LINE通知のタイミングと対象を修正

### DIFF
--- a/src/server/services/lineService.ts
+++ b/src/server/services/lineService.ts
@@ -4,6 +4,29 @@ import { prisma } from "@/server/db";
 const LINE_MULTICAST_ENDPOINT = "https://api.line.me/v2/bot/message/multicast";
 const LINE_PUSH_ENDPOINT = "https://api.line.me/v2/bot/message/push";
 
+/**
+ * 通知間隔（notificationDays）に基づいて通知対象かどうかを判定
+ * @param lastNotifiedAt 最後に通知した日時
+ * @param notificationDays 通知間隔（日数）
+ * @returns 通知すべきならtrue
+ */
+function shouldNotify(
+  lastNotifiedAt: Date | null,
+  notificationDays: number
+): boolean {
+  if (!lastNotifiedAt) {
+    // 一度も通知していない場合は通知する
+    return true;
+  }
+
+  const now = new Date();
+  const daysSinceLastNotification = Math.floor(
+    (now.getTime() - lastNotifiedAt.getTime()) / (1000 * 60 * 60 * 24)
+  );
+
+  return daysSinceLastNotification >= notificationDays;
+}
+
 export async function sendLineBroadcast(message: string) {
   const token = process.env.LINE_CHANNEL_ACCESS_TOKEN;
   if (!token) {
@@ -11,29 +34,47 @@ export async function sendLineBroadcast(message: string) {
     return;
   }
 
-  // Get all subscribers (users)
+  const now = new Date();
+
+  // Get all subscribers (users) with their notification settings
   const subscribers = await prisma.lineSubscriber.findMany({
-    select: { userId: true },
+    select: { userId: true, notificationDays: true, lastNotifiedAt: true },
   });
-  const userIds = subscribers.map((s) => s.userId);
 
-  // Get all groups
+  // Filter subscribers based on notification interval
+  const eligibleSubscribers = subscribers.filter((s) =>
+    shouldNotify(s.lastNotifiedAt, s.notificationDays)
+  );
+  const userIds = eligibleSubscribers.map((s) => s.userId);
+
+  // Get all groups with their notification settings
   const groups = await prisma.lineGroup.findMany({
-    select: { id: true, type: true },
+    select: { id: true, type: true, notificationDays: true, lastNotifiedAt: true },
   });
 
-  if (userIds.length === 0 && groups.length === 0) {
-    console.log("No recipients to send message to");
+  // Filter groups based on notification interval
+  const eligibleGroups = groups.filter((g) =>
+    shouldNotify(g.lastNotifiedAt, g.notificationDays)
+  );
+
+  console.log(
+    `Notification eligibility: ${userIds.length}/${subscribers.length} users, ${eligibleGroups.length}/${groups.length} groups/rooms`
+  );
+
+  if (userIds.length === 0 && eligibleGroups.length === 0) {
+    console.log("No recipients to send message to (all filtered by notification interval)");
     return;
   }
 
   console.log(
-    `Sending to ${userIds.length + groups.length} recipients (${userIds.length} users, ${groups.length} groups/rooms)`
+    `Sending to ${userIds.length + eligibleGroups.length} recipients (${userIds.length} users, ${eligibleGroups.length} groups/rooms)`
   );
 
   // LINE multicast API has a limit of 500 recipients per request
   // Split into batches if needed
   const batchSize = 500;
+  const successfulUserIds: string[] = [];
+  const successfulGroupIds: string[] = [];
 
   // 1) Send to individual users via multicast
   for (let i = 0; i < userIds.length; i += batchSize) {
@@ -56,11 +97,12 @@ export async function sendLineBroadcast(message: string) {
       console.error("LINE multicast error", res.status, body);
     } else {
       console.log(`Sent user batch ${i / batchSize + 1} successfully`);
+      successfulUserIds.push(...batch);
     }
   }
 
   // 2) Send to groups/rooms via push API (multicast does not accept group IDs)
-  for (const group of groups) {
+  for (const group of eligibleGroups) {
     const res = await fetch(LINE_PUSH_ENDPOINT, {
       method: "POST",
       headers: {
@@ -82,6 +124,24 @@ export async function sendLineBroadcast(message: string) {
       );
     } else {
       console.log(`Sent message to ${group.type} ${group.id}`);
+      successfulGroupIds.push(group.id);
     }
+  }
+
+  // 3) Update lastNotifiedAt for successful recipients
+  if (successfulUserIds.length > 0) {
+    await prisma.lineSubscriber.updateMany({
+      where: { userId: { in: successfulUserIds } },
+      data: { lastNotifiedAt: now },
+    });
+    console.log(`Updated lastNotifiedAt for ${successfulUserIds.length} users`);
+  }
+
+  if (successfulGroupIds.length > 0) {
+    await prisma.lineGroup.updateMany({
+      where: { id: { in: successfulGroupIds } },
+      data: { lastNotifiedAt: now },
+    });
+    console.log(`Updated lastNotifiedAt for ${successfulGroupIds.length} groups`);
   }
 }


### PR DESCRIPTION
## Summary

- LINE通知が `notificationDays`（通知間隔）設定を無視して全員に送信されていた問題を修正
- `lastNotifiedAt`（最終通知日時）に基づいて通知対象をフィルタリング
- 通知成功後に `lastNotifiedAt` を更新するロジックを追加

## 問題の詳細

### 修正前
- DBスキーマに `notificationDays` と `lastNotifiedAt` が定義されていた
- LINE Webhookでこれらの値を設定するコードが存在していた
- **しかし、Cronジョブ実行時の `sendLineBroadcast()` ではこれらを参照せず、全員に通知していた**

### 修正後
- `shouldNotify()` 関数で通知間隔を判定
- 間隔が経過したユーザー/グループのみに通知
- 通知成功後に `lastNotifiedAt` を現在時刻に更新

## Test plan

- [ ] 通知間隔が1日のユーザーに毎日通知が届くことを確認
- [ ] 通知間隔が7日のユーザーに1週間後まで通知が届かないことを確認
- [ ] `lastNotifiedAt` が通知成功後に更新されることをDBで確認
- [ ] 通知失敗時は `lastNotifiedAt` が更新されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 改善

* **バグ修正**
  * 通知の送信間隔設定を尊重し、過度な通知の送信を防止しました。

* **改善**
  * 通知システムの追跡機能を強化し、送信成功履歴の記録と最終送信時刻の更新処理を実装しました。ユーザーおよびグループの通知受信資格をフィルタリングし、適格な受信者のみに通知を送信するようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->