### PR TITLE
feat: イベント通知システムの改善

### DIFF
--- a/prisma/migrations/20260118000000_update_notification_days_default/migration.sql
+++ b/prisma/migrations/20260118000000_update_notification_days_default/migration.sql
@@ -1,0 +1,3 @@
+-- Update default value for notificationDays from 1 to 7 (weekly notification)
+ALTER TABLE "LineSubscriber" ALTER COLUMN "notificationDays" SET DEFAULT 7;
+ALTER TABLE "LineGroup" ALTER COLUMN "notificationDays" SET DEFAULT 7;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,7 +30,7 @@ model Event {
 
 model LineSubscriber {
   userId             String   @id
-  notificationDays   Int      @default(1)  // 通知間隔（日数）: 1, 7, 14, 30
+  notificationDays   Int      @default(7)  // 通知間隔（日数）: 1, 7, 14, 30（デフォルト週1回）
   lastNotifiedAt     DateTime?             // 最後に通知した日時
   createdAt          DateTime @default(now())
 }
@@ -38,7 +38,7 @@ model LineSubscriber {
 model LineGroup {
   id                 String   @id  // groupId or roomId
   type               String        // "group" or "room"
-  notificationDays   Int      @default(1)  // 通知間隔（日数）: 1, 7, 14, 30
+  notificationDays   Int      @default(7)  // 通知間隔（日数）: 1, 7, 14, 30（デフォルト週1回）
   lastNotifiedAt     DateTime?             // 最後に通知した日時
   createdAt          DateTime @default(now())
 }

--- a/src/app/api/cron/sync-events/route.ts
+++ b/src/app/api/cron/sync-events/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { crawlBeergirlCalendar } from "@/server/crawlers/beergirlCalendar";
 import { crawlWalkerplus } from "@/server/crawlers/walkerplus";
+import { crawlBeerfestival } from "@/server/crawlers/beerfestival";
+import { crawlAlwaysLoveBeer } from "@/server/crawlers/alwayslovebeer";
 import { upsertEventsAndGetNewOnes } from "@/server/services/eventService";
 import { sendLineBroadcast } from "@/server/services/lineService";
 
@@ -17,10 +19,12 @@ export async function GET(request: Request) {
 
     console.log("Starting cron job...");
     const allNewMessages: string[] = [];
+    const crawledCounts: Record<string, number> = {};
 
     // 1. ビール女子カレンダー（Googleカレンダー）
     console.log("Crawling beergirl calendar...");
     const beergirlCalendarItems = await crawlBeergirlCalendar();
+    crawledCounts.beergirlCalendar = beergirlCalendarItems.length;
     console.log(`Beergirl calendar found ${beergirlCalendarItems.length} items`);
 
     const beergirlCalendarNews = await upsertEventsAndGetNewOnes(beergirlCalendarItems);
@@ -35,6 +39,7 @@ export async function GET(request: Request) {
     // 2. Walkerplus
     console.log("Crawling walkerplus...");
     const walkerplusItems = await crawlWalkerplus();
+    crawledCounts.walkerplus = walkerplusItems.length;
     console.log(`Walkerplus found ${walkerplusItems.length} items`);
 
     const walkerplusNews = await upsertEventsAndGetNewOnes(walkerplusItems);
@@ -46,9 +51,44 @@ export async function GET(request: Request) {
       );
     }
 
+    // 3. beerfestival.info
+    console.log("Crawling beerfestival.info...");
+    const beerfestivalItems = await crawlBeerfestival();
+    crawledCounts.beerfestival = beerfestivalItems.length;
+    console.log(`Beerfestival found ${beerfestivalItems.length} items`);
+
+    const beerfestivalNews = await upsertEventsAndGetNewOnes(beerfestivalItems);
+    console.log(`Beerfestival new events: ${beerfestivalNews.length}`);
+
+    if (beerfestivalNews.length) {
+      beerfestivalNews.forEach((n) =>
+        allNewMessages.push(`🎪[ビアフェス情報] ${n.title}\n${n.url}`)
+      );
+    }
+
+    // 4. alwayslovebeer.com
+    console.log("Crawling alwayslovebeer.com...");
+    const alwayslovebeerItems = await crawlAlwaysLoveBeer();
+    crawledCounts.alwayslovebeer = alwayslovebeerItems.length;
+    console.log(`AlwaysLoveBeer found ${alwayslovebeerItems.length} items`);
+
+    const alwayslovebeerNews = await upsertEventsAndGetNewOnes(alwayslovebeerItems);
+    console.log(`AlwaysLoveBeer new events: ${alwayslovebeerNews.length}`);
+
+    if (alwayslovebeerNews.length) {
+      alwayslovebeerNews.forEach((n) =>
+        allNewMessages.push(`🍻[Always Love Beer] ${n.title}\n${n.url}`)
+      );
+    }
+
     if (allNewMessages.length) {
       console.log(`Sending ${allNewMessages.length} new events to LINE...`);
-      const text = allNewMessages.join("\n\n");
+      // Limit message length for LINE (max 5000 characters)
+      let text = "🍺 今週の新着ビールイベント\n\n" + allNewMessages.slice(0, 5).join("\n\n");
+      if (allNewMessages.length > 5) {
+        const webPageUrl = process.env.NEXT_PUBLIC_APP_URL + "/events";
+        text += `\n\n他${allNewMessages.length - 5}件あります。\n詳しくはこちら: ${webPageUrl}`;
+      }
       await sendLineBroadcast(text);
       console.log("LINE broadcast sent successfully");
     } else {
@@ -58,10 +98,7 @@ export async function GET(request: Request) {
     return NextResponse.json({
       success: true,
       newCount: allNewMessages.length,
-      crawled: {
-        beergirlCalendar: beergirlCalendarItems.length,
-        walkerplus: walkerplusItems.length,
-      },
+      crawled: crawledCounts,
     });
   } catch (error) {
     console.error("Cron job error:", error);

--- a/src/app/api/cron/sync-events/route.ts
+++ b/src/app/api/cron/sync-events/route.ts
@@ -5,6 +5,7 @@ import { crawlBeerfestival } from "@/server/crawlers/beerfestival";
 import { crawlAlwaysLoveBeer } from "@/server/crawlers/alwayslovebeer";
 import { upsertEventsAndGetNewOnes } from "@/server/services/eventService";
 import { sendLineBroadcast } from "@/server/services/lineService";
+import { EVENTS_PAGE_URL } from "@/server/constants";
 
 export const dynamic = "force-dynamic";
 
@@ -86,8 +87,7 @@ export async function GET(request: Request) {
       // Limit message length for LINE (max 5000 characters)
       let text = "🍺 今週の新着ビールイベント\n\n" + allNewMessages.slice(0, 5).join("\n\n");
       if (allNewMessages.length > 5) {
-        const webPageUrl = process.env.NEXT_PUBLIC_APP_URL + "/events";
-        text += `\n\n他${allNewMessages.length - 5}件あります。\n詳しくはこちら: ${webPageUrl}`;
+        text += `\n\n他${allNewMessages.length - 5}件あります。\n詳しくはこちら: ${EVENTS_PAGE_URL}`;
       }
       await sendLineBroadcast(text);
       console.log("LINE broadcast sent successfully");

--- a/src/app/api/line/webhook/route.ts
+++ b/src/app/api/line/webhook/route.ts
@@ -3,7 +3,9 @@ import type { WebhookEvent } from "@line/bot-sdk";
 import { prisma } from "@/server/db";
 import {
   getThisWeeksEvents,
+  getRecentEvents,
   formatEventsForLine,
+  formatRecentEventsForLine,
 } from "@/server/services/eventQueryService";
 import {
   crawlAndGetNewEvents,
@@ -122,9 +124,10 @@ export async function POST(request: Request) {
               event.replyToken,
               "🍺 ビールイベント通知ボットへようこそ！\n\n" +
                 "【使い方】\n" +
+                "• 「イベント」で直近のイベント5件を表示\n" +
                 "• 「今週のイベント」で今週のイベントを表示\n" +
                 "• 「通知 毎日」で毎日通知\n" +
-                "• 「通知 1週間」で週1回通知\n" +
+                "• 「通知 1週間」で週1回通知（デフォルト）\n" +
                 "• 「通知 2週間」で2週間に1回通知\n" +
                 "• 「通知 1ヶ月」で月1回通知"
             );
@@ -171,6 +174,7 @@ export async function POST(request: Request) {
               "🍺 ビールイベント通知ボットが参加しました！\n" +
                 "新しいイベント情報をこのグループにお届けします。\n\n" +
                 "【コマンド】\n" +
+                "• 「イベント」で直近のイベント5件を表示\n" +
                 "• 「今週のイベント」で今週のイベントを表示\n" +
                 "• 「通知 1週間」などで通知間隔を変更\n" +
                 "• 「停止」で通知を停止\n" +
@@ -238,6 +242,13 @@ export async function POST(request: Request) {
           console.log("User requested this week's events:", userId);
           const events = await getThisWeeksEvents();
           const message = formatEventsForLine(events);
+          await replyMessage(event.replyToken, message);
+        }
+        // イベント（直近5件表示）
+        else if (/^イベント$/i.test(text)) {
+          console.log("User requested recent events:", userId);
+          const events = await getRecentEvents(5);
+          const message = formatRecentEventsForLine(events);
           await replyMessage(event.replyToken, message);
         }
         // 通知間隔の変更
@@ -313,6 +324,13 @@ export async function POST(request: Request) {
           console.log("Group requested this week's events:", id);
           const events = await getThisWeeksEvents();
           const message = formatEventsForLine(events);
+          await replyMessage(event.replyToken, message);
+        }
+        // イベント（直近5件表示）
+        else if (/^イベント$/i.test(text)) {
+          console.log("Group requested recent events:", id);
+          const events = await getRecentEvents(5);
+          const message = formatRecentEventsForLine(events);
           await replyMessage(event.replyToken, message);
         }
         // 通知間隔の変更

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -1,0 +1,159 @@
+import { prisma } from "@/server/db";
+import { Prisma } from "../../../generated/prisma";
+
+export const dynamic = "force-dynamic";
+
+export default async function EventsPage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ source?: string; q?: string }>;
+}) {
+  const params = await searchParams;
+  const source = params?.source ?? "";
+  const q = params?.q ?? "";
+
+  const now = new Date();
+  const startOfToday = new Date(now);
+  startOfToday.setHours(0, 0, 0, 0);
+
+  // Build where clause with focus on upcoming events
+  const where: Prisma.EventWhereInput = {
+    OR: [
+      // Future events
+      {
+        eventDate: {
+          gte: startOfToday,
+        },
+      },
+      // Recent events without date (created within last 14 days)
+      {
+        eventDate: null,
+        createdAt: {
+          gte: new Date(now.getTime() - 14 * 24 * 60 * 60 * 1000),
+        },
+      },
+    ],
+  };
+
+  if (source) where.sourceId = source;
+  if (q) where.title = { contains: q };
+
+  const events = await prisma.event.findMany({
+    where,
+    orderBy: [{ eventDate: "asc" }, { createdAt: "desc" }],
+    take: 50,
+    include: { source: true },
+  });
+
+  const sources = await prisma.source.findMany();
+
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-slate-950 via-slate-950 to-black text-slate-50">
+      <div className="max-w-5xl mx-auto px-4 py-6 md:py-10">
+        <header className="mb-6 md:mb-8">
+          <div className="flex items-center gap-2 mb-2">
+            <div className="w-9 h-9 rounded-2xl bg-emerald-400/15 border border-emerald-400/40 flex items-center justify-center text-emerald-300">
+              🍺
+            </div>
+            <h1 className="text-2xl md:text-3xl font-semibold tracking-tight">
+              ビール・お酒イベント一覧
+            </h1>
+          </div>
+          <p className="text-xs md:text-sm text-slate-400">
+            ビール女子、Walkerplus、クラフトビールサイトから取得した直近のイベント情報
+          </p>
+        </header>
+
+        <section className="mb-4 md:mb-6">
+          <form className="flex flex-col md:flex-row gap-2 md:items-center">
+            <input
+              name="q"
+              defaultValue={q}
+              placeholder="キーワード検索（例：ビアフェス、IPA、渋谷）"
+              className="flex-1 px-3 py-2 text-xs md:text-sm rounded-2xl bg-white/5 border border-white/10 text-slate-50 placeholder:text-slate-500 outline-none focus:border-emerald-400/80 focus:ring-1 focus:ring-emerald-400/50 transition-all"
+            />
+            <select
+              name="source"
+              defaultValue={source}
+              className="px-3 py-2 text-xs md:text-sm rounded-2xl bg-white/5 border border-white/10 text-slate-50 outline-none focus:border-emerald-400/80 focus:ring-1 focus:ring-emerald-400/50 transition-all"
+            >
+              <option value="">すべてのソース</option>
+              {sources.map((s) => (
+                <option key={s.id} value={s.id}>
+                  {s.name || s.id}
+                </option>
+              ))}
+            </select>
+            <button
+              type="submit"
+              className="px-4 py-2 text-xs md:text-sm rounded-2xl bg-emerald-500 hover:bg-emerald-400 text-slate-950 font-semibold transition-all shadow-sm hover:shadow-md"
+            >
+              絞り込み
+            </button>
+          </form>
+        </section>
+
+        <section>
+          {events.length === 0 ? (
+            <div className="mt-6 text-xs text-slate-400">
+              条件に合うイベントがまだありません。
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3 md:gap-4">
+              {events.map((e) => {
+                const eventDateStr = e.eventDate
+                  ? `${e.eventDate.getMonth() + 1}/${e.eventDate.getDate()}`
+                  : null;
+
+                const createdAt = e.createdAt;
+                const createdAtStr = `${createdAt.getFullYear()}-${String(
+                  createdAt.getMonth() + 1
+                ).padStart(2, "0")}-${String(createdAt.getDate()).padStart(
+                  2,
+                  "0"
+                )}`;
+
+                return (
+                  <a
+                    key={e.id}
+                    href={e.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="block rounded-2xl border border-white/5 bg-gradient-to-br from-white/5 to-white/0 hover:from-white/10 hover:border-emerald-300/30 transition-all shadow-sm hover:shadow-lg backdrop-blur-sm p-4"
+                  >
+                    <div className="flex items-center gap-2 text-[10px] text-emerald-300/80 mb-1 flex-wrap">
+                      <span className="px-2 py-0.5 rounded-full bg-emerald-900/70 border border-emerald-400/40">
+                        {e.source.name || e.sourceId}
+                      </span>
+                      {eventDateStr && (
+                        <span className="px-2 py-0.5 rounded-full bg-amber-900/70 border border-amber-400/40 text-amber-300">
+                          📅 {eventDateStr}
+                        </span>
+                      )}
+                      <span className="text-slate-400">登録: {createdAtStr}</span>
+                    </div>
+                    <h2 className="text-sm md:text-base font-semibold text-slate-50 leading-snug line-clamp-2">
+                      {e.title}
+                    </h2>
+                    <p className="mt-2 text-[10px] text-emerald-200/80 break-all line-clamp-1">
+                      {e.url}
+                    </p>
+                  </a>
+                );
+              })}
+            </div>
+          )}
+        </section>
+
+        <footer className="mt-8 pt-6 border-t border-white/10 text-center">
+          <p className="text-xs text-slate-500">
+            🍺 ビールイベント通知Bot - 毎週金曜日に新着イベントをLINEでお届け
+          </p>
+          <p className="text-[10px] text-slate-600 mt-1">
+            ソース: ビール女子 / Walkerplus / クラフトビール専門サイト
+          </p>
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -60,7 +60,7 @@ export default async function EventsPage({
             </h1>
           </div>
           <p className="text-xs md:text-sm text-slate-400">
-            ビール女子、Walkerplus、クラフトビールサイトから取得した直近のイベント情報
+            ビール女子 / Walkerplus / beerfestival.info / alwayslovebeer.com から取得した直近のイベント情報
           </p>
         </header>
 
@@ -150,7 +150,7 @@ export default async function EventsPage({
             🍺 ビールイベント通知Bot - 毎週金曜日に新着イベントをLINEでお届け
           </p>
           <p className="text-[10px] text-slate-600 mt-1">
-            ソース: ビール女子 / Walkerplus / クラフトビール専門サイト
+            ソース: {sources.length > 0 ? sources.map(s => s.name || s.id).join(" / ") : "ビール女子 / Walkerplus / beerfestival.info / alwayslovebeer.com"}
           </p>
         </footer>
       </div>

--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -1,0 +1,9 @@
+/**
+ * Application constants
+ */
+
+// Web application URL
+export const APP_URL = "https://beer-line-watcher.vercel.app";
+
+// Events page URL for LINE messages
+export const EVENTS_PAGE_URL = `${APP_URL}/events`;

--- a/src/server/crawlers/alwayslovebeer.ts
+++ b/src/server/crawlers/alwayslovebeer.ts
@@ -1,0 +1,133 @@
+import type { CrawledItem } from "./types";
+import { extractDateFromText } from "../utils/dateExtractor";
+
+const SOURCE_ID = "alwayslovebeer";
+const BASE_URL = "https://www.alwayslovebeer.com/latest-beer-event-infomation/";
+
+/**
+ * Crawler for alwayslovebeer.com event page
+ * This site provides regularly updated beer event information
+ */
+export async function crawlAlwaysLoveBeer(): Promise<CrawledItem[]> {
+  const items: CrawledItem[] = [];
+
+  try {
+    const res = await fetch(BASE_URL, {
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (compatible; BeerEventBot/1.0; +https://github.com/Makoto041/beer-line-watcher)",
+      },
+    });
+
+    if (!res.ok) {
+      console.error("alwayslovebeer.com fetch error", res.status);
+      return items;
+    }
+
+    const html = await res.text();
+
+    // Extract h3 headings with event info
+    // Pattern: 【date】prefecture：event name or similar
+    // Example: 【1/17[土]】静岡：貯蔵クラフトビール開封フェス
+    const h3Regex = /<h3[^>]*>([^<]+)<\/h3>/gi;
+    let match: RegExpExecArray | null;
+
+    // Track position to find associated links
+    const headings: Array<{ text: string; index: number }> = [];
+    while ((match = h3Regex.exec(html)) !== null) {
+      const text = match[1];
+      if (text) {
+        headings.push({ text: text.trim(), index: match.index });
+      }
+    }
+
+    // For each heading, find the next link
+    const linkRegex = /<a[^>]+href="(https?:\/\/[^"]+)"[^>]*>/gi;
+    const links: Array<{ url: string; index: number }> = [];
+    while ((match = linkRegex.exec(html)) !== null) {
+      const url = match[1];
+      if (!url) continue;
+      // Skip social media and internal links
+      if (
+        url.includes("twitter.com") ||
+        url.includes("facebook.com") ||
+        url.includes("instagram.com") ||
+        url.includes("alwayslovebeer.com")
+      ) {
+        continue;
+      }
+      links.push({ url, index: match.index });
+    }
+
+    // Match headings with their associated links
+    for (const heading of headings) {
+      // Check if heading looks like an event
+      const eventPattern = /【.*】|^\d{1,2}\/\d{1,2}|月.*日|フェス|祭|イベント|ビール/;
+      if (!eventPattern.test(heading.text)) continue;
+
+      // Find the closest link after this heading
+      const nextLink = links.find(
+        (l) => l.index > heading.index && l.index < heading.index + 2000
+      );
+
+      if (nextLink) {
+        // Clean up the title
+        let title = heading.text
+          .replace(/\s+/g, " ")
+          .replace(/^【[^】]*】\s*/, "")
+          .trim();
+
+        // If title is too short, skip
+        if (title.length < 5) continue;
+
+        // Extract date from the original heading
+        const eventDate = extractDateFromText(heading.text);
+
+        items.push({
+          externalId: nextLink.url,
+          title: title,
+          url: nextLink.url,
+          sourceId: SOURCE_ID,
+          eventDate: eventDate || undefined,
+        });
+      }
+    }
+
+    // Also extract from structured article links
+    const articleRegex =
+      /<article[^>]*>[\s\S]*?<a[^>]+href="([^"]+)"[^>]*>[\s\S]*?<h[23][^>]*>([^<]+)<\/h[23]>/gi;
+    while ((match = articleRegex.exec(html)) !== null) {
+      const url = match[1];
+      const titleRaw = match[2];
+
+      if (!url || !titleRaw) continue;
+      const title = titleRaw.trim();
+      if (title.length < 5) continue;
+      if (!url.startsWith("http")) continue;
+      if (items.some((i) => i.externalId === url)) continue;
+
+      const eventDate = extractDateFromText(title);
+
+      items.push({
+        externalId: url,
+        title: title,
+        url: url,
+        sourceId: SOURCE_ID,
+        eventDate: eventDate || undefined,
+      });
+    }
+  } catch (error) {
+    console.error("alwayslovebeer.com crawl error:", error);
+  }
+
+  return dedupe(items);
+}
+
+function dedupe(items: CrawledItem[]): CrawledItem[] {
+  const set = new Set<string>();
+  return items.filter((i) => {
+    if (set.has(i.externalId)) return false;
+    set.add(i.externalId);
+    return true;
+  });
+}

--- a/src/server/crawlers/beerfestival.ts
+++ b/src/server/crawlers/beerfestival.ts
@@ -1,0 +1,132 @@
+import type { CrawledItem } from "./types";
+import { extractDateFromText } from "../utils/dateExtractor";
+
+const SOURCE_ID = "beerfestival-info";
+const BASE_URL = "https://www.beerfestival.info/";
+
+/**
+ * Crawler for beerfestival.info
+ * This site lists beer festivals and events across Japan
+ */
+export async function crawlBeerfestival(): Promise<CrawledItem[]> {
+  const items: CrawledItem[] = [];
+
+  try {
+    const res = await fetch(BASE_URL, {
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (compatible; BeerEventBot/1.0; +https://github.com/Makoto041/beer-line-watcher)",
+      },
+    });
+
+    if (!res.ok) {
+      console.error("beerfestival.info fetch error", res.status);
+      return items;
+    }
+
+    const html = await res.text();
+
+    // Extract event links with titles and dates
+    // Pattern: dates followed by event link
+    // Example: 1月28日（水）〜2月1日（日） <a href="...">Event Name</a>
+    const eventRegex =
+      /(\d{1,2}月\d{1,2}日[^<]*?)<a[^>]+href="([^"]+)"[^>]*>([^<]+)<\/a>/gi;
+    let match: RegExpExecArray | null;
+
+    while ((match = eventRegex.exec(html)) !== null) {
+      const dateTextRaw = match[1];
+      const url = match[2];
+      const titleRaw = match[3];
+
+      // Skip navigation links and non-event links
+      if (!dateTextRaw || !url || !titleRaw) continue;
+
+      const dateText = dateTextRaw.trim();
+      const title = titleRaw.trim();
+
+      if (
+        url.includes("#") ||
+        url.includes("javascript:") ||
+        title.length < 5
+      ) {
+        continue;
+      }
+
+      // Skip archive links (year pages)
+      if (/^\d{4}$/.test(title)) continue;
+
+      // Skip city/region navigation links
+      if (/^(東京|大阪|名古屋|福岡|札幌|横浜|神戸|京都|全国)$/.test(title))
+        continue;
+
+      // Build absolute URL
+      const absoluteUrl = url.startsWith("http")
+        ? url
+        : new URL(url, BASE_URL).toString();
+
+      // Extract event date
+      const eventDate = extractDateFromText(dateText) || extractDateFromText(title);
+
+      items.push({
+        externalId: absoluteUrl,
+        title: title,
+        url: absoluteUrl,
+        sourceId: SOURCE_ID,
+        eventDate: eventDate || undefined,
+      });
+    }
+
+    // Also try to match simple list items without date prefix
+    const simpleLinkRegex =
+      /<li[^>]*><a[^>]+href="([^"]+)"[^>]*>([^<]{10,100})<\/a><\/li>/gi;
+    while ((match = simpleLinkRegex.exec(html)) !== null) {
+      const url = match[1];
+      const titleRaw = match[2];
+
+      if (!url || !titleRaw) continue;
+      const title = titleRaw.trim();
+
+      if (
+        url.includes("#") ||
+        url.includes("javascript:")
+      ) {
+        continue;
+      }
+
+      // Skip if already added
+      const absoluteUrl = url.startsWith("http")
+        ? url
+        : new URL(url, BASE_URL).toString();
+
+      if (items.some((i) => i.externalId === absoluteUrl)) continue;
+
+      // Check for event-related keywords
+      const eventKeywords =
+        /フェス|祭|イベント|開催|ビアガーデン|マルシェ|フェア|オクトーバー|beer|fest/i;
+      if (!eventKeywords.test(title)) continue;
+
+      const eventDate = extractDateFromText(title);
+
+      items.push({
+        externalId: absoluteUrl,
+        title: title,
+        url: absoluteUrl,
+        sourceId: SOURCE_ID,
+        eventDate: eventDate || undefined,
+      });
+    }
+  } catch (error) {
+    console.error("beerfestival.info crawl error:", error);
+  }
+
+  return dedupe(items);
+}
+
+function dedupe(items: CrawledItem[]): CrawledItem[] {
+  const set = new Set<string>();
+  return items.filter((i) => {
+    if (set.has(i.externalId)) return false;
+    set.add(i.externalId);
+    return true;
+  });
+}

--- a/src/server/services/crawlerService.ts
+++ b/src/server/services/crawlerService.ts
@@ -3,6 +3,7 @@ import { crawlWalkerplus } from "@/server/crawlers/walkerplus";
 import { crawlBeerfestival } from "@/server/crawlers/beerfestival";
 import { crawlAlwaysLoveBeer } from "@/server/crawlers/alwayslovebeer";
 import { upsertEventsAndGetNewOnes } from "@/server/services/eventService";
+import { EVENTS_PAGE_URL } from "@/server/constants";
 
 interface SourceSummary {
   total: number;
@@ -128,9 +129,8 @@ export function formatCrawlerResultsForLine(
     });
 
     if (newEvents.length > 3) {
-      const webPageUrl = process.env.NEXT_PUBLIC_APP_URL + "/events";
       lines.push(`他${newEvents.length - 3}件の新着イベントがあります。`);
-      lines.push(`詳しくはこちら: ${webPageUrl}`);
+      lines.push(`詳しくはこちら: ${EVENTS_PAGE_URL}`);
     }
   }
 

--- a/src/server/services/crawlerService.ts
+++ b/src/server/services/crawlerService.ts
@@ -1,6 +1,13 @@
 import { crawlBeergirlCalendar } from "@/server/crawlers/beergirlCalendar";
 import { crawlWalkerplus } from "@/server/crawlers/walkerplus";
+import { crawlBeerfestival } from "@/server/crawlers/beerfestival";
+import { crawlAlwaysLoveBeer } from "@/server/crawlers/alwayslovebeer";
 import { upsertEventsAndGetNewOnes } from "@/server/services/eventService";
+
+interface SourceSummary {
+  total: number;
+  new: number;
+}
 
 /**
  * Crawl all sources and get new events
@@ -9,8 +16,10 @@ import { upsertEventsAndGetNewOnes } from "@/server/services/eventService";
 export async function crawlAndGetNewEvents(): Promise<{
   newEvents: Array<{ title: string; url: string; sourceId: string }>;
   summary: {
-    beergirlCalendar: { total: number; new: number };
-    walkerplus: { total: number; new: number };
+    beergirlCalendar: SourceSummary;
+    walkerplus: SourceSummary;
+    beerfestival: SourceSummary;
+    alwayslovebeer: SourceSummary;
   };
 }> {
   const allNewEvents: Array<{ title: string; url: string; sourceId: string }> =
@@ -28,6 +37,18 @@ export async function crawlAndGetNewEvents(): Promise<{
   const walkerplusNews = await upsertEventsAndGetNewOnes(walkerplusItems);
   allNewEvents.push(...walkerplusNews);
 
+  // Crawl beerfestival.info
+  console.log("Crawling beerfestival.info...");
+  const beerfestivalItems = await crawlBeerfestival();
+  const beerfestivalNews = await upsertEventsAndGetNewOnes(beerfestivalItems);
+  allNewEvents.push(...beerfestivalNews);
+
+  // Crawl alwayslovebeer.com
+  console.log("Crawling alwayslovebeer.com...");
+  const alwayslovebeerItems = await crawlAlwaysLoveBeer();
+  const alwayslovebeerNews = await upsertEventsAndGetNewOnes(alwayslovebeerItems);
+  allNewEvents.push(...alwayslovebeerNews);
+
   return {
     newEvents: allNewEvents,
     summary: {
@@ -39,8 +60,29 @@ export async function crawlAndGetNewEvents(): Promise<{
         total: walkerplusItems.length,
         new: walkerplusNews.length,
       },
+      beerfestival: {
+        total: beerfestivalItems.length,
+        new: beerfestivalNews.length,
+      },
+      alwayslovebeer: {
+        total: alwayslovebeerItems.length,
+        new: alwayslovebeerNews.length,
+      },
     },
   };
+}
+
+/**
+ * Get source display name
+ */
+function getSourceDisplayName(sourceId: string): string {
+  const names: Record<string, string> = {
+    "beergirl-calendar": "ビール女子",
+    "walkerplus-liquor-kanto": "ウォーカープラス",
+    "beerfestival-info": "ビアフェス情報",
+    alwayslovebeer: "Always Love Beer",
+  };
+  return names[sourceId] || sourceId;
 }
 
 /**
@@ -49,8 +91,10 @@ export async function crawlAndGetNewEvents(): Promise<{
 export function formatCrawlerResultsForLine(
   newEvents: Array<{ title: string; url: string; sourceId: string }>,
   summary: {
-    beergirlCalendar: { total: number; new: number };
-    walkerplus: { total: number; new: number };
+    beergirlCalendar: SourceSummary;
+    walkerplus: SourceSummary;
+    beerfestival: SourceSummary;
+    alwayslovebeer: SourceSummary;
   }
 ): string {
   const lines = ["🔄 最新情報を取得しました\n"];
@@ -58,10 +102,16 @@ export function formatCrawlerResultsForLine(
   // Summary
   lines.push("【取得結果】");
   lines.push(
-    `🍺 ビール女子カレンダー: ${summary.beergirlCalendar.total}件中${summary.beergirlCalendar.new}件が新規`
+    `🍺 ビール女子: ${summary.beergirlCalendar.total}件中${summary.beergirlCalendar.new}件が新規`
   );
   lines.push(
-    `🍷 ウォーカープラス: ${summary.walkerplus.total}件中${summary.walkerplus.new}件が新規\n`
+    `🍷 ウォーカープラス: ${summary.walkerplus.total}件中${summary.walkerplus.new}件が新規`
+  );
+  lines.push(
+    `🎪 ビアフェス情報: ${summary.beerfestival.total}件中${summary.beerfestival.new}件が新規`
+  );
+  lines.push(
+    `🍻 Always Love Beer: ${summary.alwayslovebeer.total}件中${summary.alwayslovebeer.new}件が新規\n`
   );
 
   // Show new events (max 3 for new items)
@@ -72,17 +122,15 @@ export function formatCrawlerResultsForLine(
 
     const displayEvents = newEvents.slice(0, 3);
     displayEvents.forEach((event, index) => {
-      const sourceName =
-        event.sourceId === "beergirl-calendar"
-          ? "ビール女子"
-          : "ウォーカープラス";
+      const sourceName = getSourceDisplayName(event.sourceId);
       lines.push(`${index + 1}. [${sourceName}] ${event.title}`);
       lines.push(`   ${event.url}\n`);
     });
 
     if (newEvents.length > 3) {
+      const webPageUrl = process.env.NEXT_PUBLIC_APP_URL + "/events";
       lines.push(`他${newEvents.length - 3}件の新着イベントがあります。`);
-      lines.push(`詳しくはこちら: https://beergirl.net/beer-event-matome-2017_e/`);
+      lines.push(`詳しくはこちら: ${webPageUrl}`);
     }
   }
 

--- a/src/server/services/eventQueryService.ts
+++ b/src/server/services/eventQueryService.ts
@@ -138,10 +138,63 @@ export async function getThisWeeksEvents(): Promise<
 }
 
 /**
+ * Get recent events for "イベント" command (recent 5 events)
+ */
+export async function getRecentEvents(
+  limit: number = 5
+): Promise<
+  Array<{ title: string; url: string; sourceName: string; eventDate?: Date }>
+> {
+  const now = new Date();
+  const startOfToday = new Date(now);
+  startOfToday.setHours(0, 0, 0, 0);
+
+  const events = await prisma.event.findMany({
+    where: {
+      OR: [
+        // Future events
+        {
+          eventDate: {
+            gte: startOfToday,
+          },
+        },
+        // Recent events without date (created within last 7 days)
+        {
+          eventDate: null,
+          createdAt: {
+            gte: new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000),
+          },
+        },
+      ],
+    },
+    include: {
+      source: true,
+    },
+    orderBy: [
+      {
+        eventDate: "asc",
+      },
+      {
+        createdAt: "desc",
+      },
+    ],
+    take: limit,
+  });
+
+  return events.map((event) => ({
+    title: event.title,
+    url: event.url,
+    sourceName: event.source.name,
+    eventDate: event.eventDate || undefined,
+  }));
+}
+
+/**
  * Format events as LINE message text
  */
 export function formatEventsForLine(
-  events: Array<{ title: string; url: string; sourceName: string; eventDate?: Date }>
+  events: Array<{ title: string; url: string; sourceName: string; eventDate?: Date }>,
+  options: { webPageUrl?: string } = {}
 ): string {
   if (events.length === 0) {
     return "今週のイベントが見つかりませんでした。";
@@ -159,8 +212,37 @@ export function formatEventsForLine(
 
   if (events.length === 5) {
     lines.push("※表示は最大5件です。");
-    lines.push("詳しくはこちら: https://beergirl.net/beer-event-matome-2017_e/");
+    const url = options.webPageUrl || process.env.NEXT_PUBLIC_APP_URL + "/events";
+    lines.push(`詳しくはこちら: ${url}`);
   }
+
+  return lines.join("\n");
+}
+
+/**
+ * Format recent events for "イベント" command
+ */
+export function formatRecentEventsForLine(
+  events: Array<{ title: string; url: string; sourceName: string; eventDate?: Date }>
+): string {
+  if (events.length === 0) {
+    return "現在登録されているイベントがありません。";
+  }
+
+  const lines = ["🍺 直近のイベント情報\n"];
+
+  events.forEach((event, index) => {
+    const dateStr = event.eventDate
+      ? `${event.eventDate.getMonth() + 1}/${event.eventDate.getDate()}`
+      : "日程未定";
+    const sourceEmoji = event.sourceName.includes("ビール女子") ? "🍺" : "🍷";
+    lines.push(`${index + 1}. ${sourceEmoji} [${dateStr}] ${event.title}`);
+    lines.push(`   ${event.url}\n`);
+  });
+
+  const webPageUrl = process.env.NEXT_PUBLIC_APP_URL + "/events";
+  lines.push("━━━━━━━━━━━━━━━━━━━━");
+  lines.push(`📱 すべてのイベントを見る:\n${webPageUrl}`);
 
   return lines.join("\n");
 }

--- a/src/server/services/eventQueryService.ts
+++ b/src/server/services/eventQueryService.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@/server/db";
+import { EVENTS_PAGE_URL } from "@/server/constants";
 
 /**
  * Get upcoming events (events with eventDate in the future or within last 30 days)
@@ -193,8 +194,7 @@ export async function getRecentEvents(
  * Format events as LINE message text
  */
 export function formatEventsForLine(
-  events: Array<{ title: string; url: string; sourceName: string; eventDate?: Date }>,
-  options: { webPageUrl?: string } = {}
+  events: Array<{ title: string; url: string; sourceName: string; eventDate?: Date }>
 ): string {
   if (events.length === 0) {
     return "今週のイベントが見つかりませんでした。";
@@ -212,8 +212,7 @@ export function formatEventsForLine(
 
   if (events.length === 5) {
     lines.push("※表示は最大5件です。");
-    const url = options.webPageUrl || process.env.NEXT_PUBLIC_APP_URL + "/events";
-    lines.push(`詳しくはこちら: ${url}`);
+    lines.push(`詳しくはこちら: ${EVENTS_PAGE_URL}`);
   }
 
   return lines.join("\n");
@@ -240,9 +239,8 @@ export function formatRecentEventsForLine(
     lines.push(`   ${event.url}\n`);
   });
 
-  const webPageUrl = process.env.NEXT_PUBLIC_APP_URL + "/events";
   lines.push("━━━━━━━━━━━━━━━━━━━━");
-  lines.push(`📱 すべてのイベントを見る:\n${webPageUrl}`);
+  lines.push(`📱 すべてのイベントを見る:\n${EVENTS_PAGE_URL}`);
 
   return lines.join("\n");
 }

--- a/src/server/services/eventQueryService.ts
+++ b/src/server/services/eventQueryService.ts
@@ -38,7 +38,7 @@ export async function getUpcomingEvents(
     },
     orderBy: [
       {
-        eventDate: "asc", // Events with dates first, sorted by date
+        eventDate: { sort: "asc", nulls: "last" }, // Events with dates first, sorted by date
       },
       {
         createdAt: "desc", // Then by creation date
@@ -84,7 +84,7 @@ export async function getLatestEvents(
     },
     orderBy: [
       {
-        eventDate: "asc",
+        eventDate: { sort: "asc", nulls: "last" },
       },
       {
         createdAt: "desc",
@@ -173,7 +173,7 @@ export async function getRecentEvents(
     },
     orderBy: [
       {
-        eventDate: "asc",
+        eventDate: { sort: "asc", nulls: "last" },
       },
       {
         createdAt: "desc",

--- a/src/server/services/eventService.ts
+++ b/src/server/services/eventService.ts
@@ -1,9 +1,30 @@
 import { prisma } from "@/server/db";
 import type { CrawledItem } from "../crawlers/types";
 import { createHash } from "crypto";
+import { calculateDuplicateScore } from "../utils/duplicateDetector";
+
+// Threshold for duplicate detection (0.6 = 60% similarity)
+const DUPLICATE_THRESHOLD = 0.6;
 
 export async function upsertEventsAndGetNewOnes(items: CrawledItem[]) {
   const newOnes: { title: string; url: string; sourceId: string }[] = [];
+
+  // Get existing events from the last 60 days for duplicate checking
+  const sixtyDaysAgo = new Date();
+  sixtyDaysAgo.setDate(sixtyDaysAgo.getDate() - 60);
+
+  const existingEvents = await prisma.event.findMany({
+    where: {
+      createdAt: { gte: sixtyDaysAgo },
+    },
+    select: {
+      id: true,
+      title: true,
+      url: true,
+      sourceId: true,
+      eventDate: true,
+    },
+  });
 
   for (const item of items) {
     // Ensure Source exists (auto-create if missing)
@@ -13,12 +34,12 @@ export async function upsertEventsAndGetNewOnes(items: CrawledItem[]) {
       update: {},
       create: {
         id: item.sourceId,
-        name: item.sourceId,
+        name: getSourceDisplayName(item.sourceId),
         url: origin,
       },
     });
 
-    // Check if Event already exists
+    // Check if Event already exists by ID
     const id = makeEventId(item);
     const exists = await prisma.event.findUnique({ where: { id } });
 
@@ -38,6 +59,13 @@ export async function upsertEventsAndGetNewOnes(items: CrawledItem[]) {
       continue;
     }
 
+    // Check for duplicate events from other sources
+    const isDuplicate = checkForDuplicate(item, existingEvents);
+    if (isDuplicate) {
+      console.log(`Skipping duplicate event: "${item.title}" (similar to existing)`);
+      continue;
+    }
+
     // Create new Event
     await prisma.event.create({
       data: {
@@ -49,6 +77,15 @@ export async function upsertEventsAndGetNewOnes(items: CrawledItem[]) {
       },
     });
 
+    // Add to existing events for further duplicate checking
+    existingEvents.push({
+      id,
+      title: item.title,
+      url: item.url,
+      sourceId: item.sourceId,
+      eventDate: item.eventDate || null,
+    });
+
     newOnes.push({
       title: item.title,
       url: item.url,
@@ -57,6 +94,61 @@ export async function upsertEventsAndGetNewOnes(items: CrawledItem[]) {
   }
 
   return newOnes;
+}
+
+/**
+ * Check if an item is a duplicate of any existing event
+ */
+function checkForDuplicate(
+  item: CrawledItem,
+  existingEvents: Array<{
+    id: string;
+    title: string;
+    url: string;
+    sourceId: string;
+    eventDate: Date | null;
+  }>
+): boolean {
+  for (const existing of existingEvents) {
+    // Skip same source (already handled by ID dedup)
+    if (item.sourceId === existing.sourceId) continue;
+
+    const score = calculateDuplicateScore(
+      {
+        title: item.title,
+        url: item.url,
+        eventDate: item.eventDate,
+        sourceId: item.sourceId,
+      },
+      {
+        title: existing.title,
+        url: existing.url,
+        eventDate: existing.eventDate || undefined,
+        sourceId: existing.sourceId,
+      }
+    );
+
+    if (score >= DUPLICATE_THRESHOLD) {
+      console.log(
+        `Duplicate detected (${(score * 100).toFixed(1)}%): "${item.title}" ≈ "${existing.title}"`
+      );
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Get display name for source
+ */
+function getSourceDisplayName(sourceId: string): string {
+  const names: Record<string, string> = {
+    "beergirl-calendar": "ビール女子カレンダー",
+    "walkerplus-liquor-kanto": "ウォーカープラス",
+    "beerfestival-info": "ビアフェス情報",
+    alwayslovebeer: "Always Love Beer",
+  };
+  return names[sourceId] || sourceId;
 }
 
 function makeEventId(item: CrawledItem): string {

--- a/src/server/utils/duplicateDetector.ts
+++ b/src/server/utils/duplicateDetector.ts
@@ -1,0 +1,238 @@
+/**
+ * Event duplicate detection using string similarity
+ * No external AI API required - uses local algorithms
+ */
+
+interface EventCandidate {
+  title: string;
+  url: string;
+  eventDate?: Date;
+  sourceId: string;
+}
+
+/**
+ * Normalize text for comparison
+ * - Convert to lowercase
+ * - Remove special characters and extra spaces
+ * - Normalize Japanese characters
+ */
+function normalizeText(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[\s\u3000]+/g, " ") // Normalize whitespace (including Japanese space)
+    .replace(/[【】「」『』（）()［］\[\]]/g, "") // Remove brackets
+    .replace(/[、。！？!?,.]/g, "") // Remove punctuation
+    .replace(/第(\d+)回/g, "$1") // Normalize "第N回" to just number
+    .replace(/ビアフェス|ビールフェス|ビールフェスティバル|beer\s*fest(?:ival)?/gi, "ビアフェス")
+    .replace(/オクトーバーフェスト|oktoberfest/gi, "オクトーバーフェスト")
+    .trim();
+}
+
+/**
+ * Extract key terms from event title for comparison
+ */
+function extractKeyTerms(title: string): Set<string> {
+  const normalized = normalizeText(title);
+  const terms = new Set<string>();
+
+  // Extract location keywords (common Tokyo areas)
+  const locations = [
+    "渋谷", "新宿", "池袋", "六本木", "銀座", "恵比寿", "代官山",
+    "横浜", "みなとみらい", "大阪", "梅田", "難波", "名古屋", "福岡",
+    "札幌", "神戸", "京都", "広島", "仙台", "お台場", "豊洲", "日比谷"
+  ];
+  for (const loc of locations) {
+    if (normalized.includes(loc)) {
+      terms.add(loc);
+    }
+  }
+
+  // Extract event type keywords
+  const eventTypes = [
+    "ビアフェス", "ビアガーデン", "オクトーバーフェスト", "クラフトビール",
+    "地ビール", "ブルワリー", "醸造", "試飲", "飲み比べ", "タップ",
+    "フェスティバル", "フェス", "祭", "マルシェ", "フェア"
+  ];
+  for (const type of eventTypes) {
+    if (normalized.includes(type)) {
+      terms.add(type);
+    }
+  }
+
+  // Extract numbers (often year or edition)
+  const numbers = normalized.match(/\d+/g);
+  if (numbers) {
+    numbers.forEach((n) => terms.add(n));
+  }
+
+  return terms;
+}
+
+/**
+ * Calculate Jaccard similarity between two sets
+ */
+function jaccardSimilarity(set1: Set<string>, set2: Set<string>): number {
+  if (set1.size === 0 && set2.size === 0) return 1;
+  if (set1.size === 0 || set2.size === 0) return 0;
+
+  const intersection = new Set([...set1].filter((x) => set2.has(x)));
+  const union = new Set([...set1, ...set2]);
+
+  return intersection.size / union.size;
+}
+
+/**
+ * Calculate simple character-based similarity (bigram)
+ */
+function bigramSimilarity(s1: string, s2: string): number {
+  const getBigrams = (s: string): Set<string> => {
+    const bigrams = new Set<string>();
+    for (let i = 0; i < s.length - 1; i++) {
+      bigrams.add(s.slice(i, i + 2));
+    }
+    return bigrams;
+  };
+
+  const bigrams1 = getBigrams(normalizeText(s1));
+  const bigrams2 = getBigrams(normalizeText(s2));
+
+  return jaccardSimilarity(bigrams1, bigrams2);
+}
+
+/**
+ * Check if two events are on the same date (or within a close range)
+ */
+function isSameDate(date1?: Date, date2?: Date): boolean {
+  if (!date1 || !date2) return false;
+
+  // Same day
+  return (
+    date1.getFullYear() === date2.getFullYear() &&
+    date1.getMonth() === date2.getMonth() &&
+    date1.getDate() === date2.getDate()
+  );
+}
+
+/**
+ * Check if two events are likely duplicates
+ * Returns a confidence score between 0 and 1
+ */
+export function calculateDuplicateScore(
+  event1: EventCandidate,
+  event2: EventCandidate
+): number {
+  // Same source = not considered duplicate (already deduped within source)
+  if (event1.sourceId === event2.sourceId) return 0;
+
+  // Calculate term similarity
+  const terms1 = extractKeyTerms(event1.title);
+  const terms2 = extractKeyTerms(event2.title);
+  const termSimilarity = jaccardSimilarity(terms1, terms2);
+
+  // Calculate bigram similarity
+  const titleSimilarity = bigramSimilarity(event1.title, event2.title);
+
+  // Date match bonus
+  const dateMatch = isSameDate(event1.eventDate, event2.eventDate) ? 0.2 : 0;
+
+  // Combined score (weighted average)
+  const score =
+    termSimilarity * 0.4 + // Key terms are important
+    titleSimilarity * 0.4 + // Title similarity
+    dateMatch; // Date match bonus
+
+  return Math.min(score, 1);
+}
+
+/**
+ * Find duplicate events in a list
+ * Returns events with duplicates marked
+ */
+export function findDuplicates(
+  events: EventCandidate[],
+  threshold: number = 0.6
+): Array<EventCandidate & { duplicateOf?: string; score?: number }> {
+  const result: Array<EventCandidate & { duplicateOf?: string; score?: number }> = [];
+  const processed: EventCandidate[] = [];
+
+  for (const event of events) {
+    let isDuplicate = false;
+    let bestMatch: { event: EventCandidate; score: number } | null = null;
+
+    for (const existing of processed) {
+      const score = calculateDuplicateScore(event, existing);
+      if (score >= threshold) {
+        if (!bestMatch || score > bestMatch.score) {
+          bestMatch = { event: existing, score };
+        }
+        isDuplicate = true;
+      }
+    }
+
+    if (isDuplicate && bestMatch) {
+      result.push({
+        ...event,
+        duplicateOf: bestMatch.event.title,
+        score: bestMatch.score,
+      });
+    } else {
+      result.push(event);
+      processed.push(event);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Filter out duplicate events, keeping only unique ones
+ * Priority: beergirl-calendar > walkerplus > beerfestival > alwayslovebeer
+ */
+export function removeDuplicates(
+  events: EventCandidate[],
+  threshold: number = 0.6
+): EventCandidate[] {
+  // Sort by priority (lower index = higher priority)
+  const priorityOrder = [
+    "beergirl-calendar",
+    "walkerplus-liquor-kanto",
+    "beerfestival-info",
+    "alwayslovebeer",
+  ];
+
+  const sortedEvents = [...events].sort((a, b) => {
+    const priorityA = priorityOrder.indexOf(a.sourceId);
+    const priorityB = priorityOrder.indexOf(b.sourceId);
+    return (
+      (priorityA === -1 ? 999 : priorityA) -
+      (priorityB === -1 ? 999 : priorityB)
+    );
+  });
+
+  const unique: EventCandidate[] = [];
+
+  for (const event of sortedEvents) {
+    let isDuplicate = false;
+
+    for (const existing of unique) {
+      const score = calculateDuplicateScore(event, existing);
+      if (score >= threshold) {
+        console.log(
+          `Duplicate detected (${(score * 100).toFixed(1)}%): "${event.title}" ≈ "${existing.title}"`
+        );
+        isDuplicate = true;
+        break;
+      }
+    }
+
+    if (!isDuplicate) {
+      unique.push(event);
+    }
+  }
+
+  console.log(
+    `Duplicate removal: ${events.length} events -> ${unique.length} unique`
+  );
+
+  return unique;
+}

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/cron/sync-events?token=3a9dfc92b1e7480f9d234bc991e3a2a1",
-      "schedule": "0 0 * * *"
+      "schedule": "0 9 * * 5"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- **「イベント」コマンド追加**: LINEで「イベント」と送ると直近5件のイベントを表示
- **イベント一覧Webページ作成**: `/events` パスで直近イベント一覧を閲覧可能
- **Cron実行タイミング変更**: 毎日 → 毎週金曜日 18:00 JST（UTC 09:00）
- **新規情報ソース追加**:
  - beerfestival.info（ビアフェス情報）
  - alwayslovebeer.com（Always Love Beer）
- **デフォルト通知間隔変更**: 1日 → 7日（週1回通知）
- **ウェルカムメッセージ更新**: 新コマンドの説明を追加

## 情報ソース（4サイト）

| ソース | 説明 |
|--------|------|
| ビール女子カレンダー | Google Calendar経由でイベント取得 |
| Walkerplus | 関東お酒イベント検索 |
| beerfestival.info | 全国ビアフェス情報 |
| alwayslovebeer.com | ビールイベント情報（随時更新） |

## LINEコマンド

| コマンド | 機能 |
|----------|------|
| `イベント` | 直近5件のイベントを表示 + Webページへ誘導 |
| `今週のイベント` | 今週のイベントを表示 |
| `通知 〇〇` | 通知間隔を変更（毎日/1週間/2週間/1ヶ月） |

## Test plan

- [ ] 「イベント」コマンドで直近5件が表示されることを確認
- [ ] `/events` ページが正常に表示されることを確認
- [ ] 新規クローラー（beerfestival, alwayslovebeer）がイベントを取得できることを確認
- [ ] Cronジョブが金曜日に実行されることを確認
- [ ] デフォルト通知間隔が7日になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 2つの新しいイベント情報源を追加しクロール対象を拡張しました。
  * イベント一覧ページを公開しました。
  * LINEで直近5件を表示する新コマンド「イベント」を追加しました。

* **改善**
  * 通知間隔のデフォルトを1日→7日（週単位）に変更しました。
  * 配信メッセージを先頭5件に制限し、詳細ページへのリンクを追加しました。
  * 定期クロールを週次に変更しました。
  * サイト横断の重複検出と抑制を導入しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->