### PR TITLE
fix: LINE通知メッセージの5000文字制限対応

### DIFF
--- a/src/app/api/cron/sync-events/route.ts
+++ b/src/app/api/cron/sync-events/route.ts
@@ -9,6 +9,55 @@ import { EVENTS_PAGE_URL } from "@/server/constants";
 
 export const dynamic = "force-dynamic";
 
+// LINE message character limit
+const MAX_LINE_CHARS = 5000;
+
+/**
+ * Build LINE message from event items with character limit enforcement
+ */
+function buildLineMessage(
+  header: string,
+  items: string[],
+  overflowUrlSuffix: string
+): string {
+  if (items.length === 0) return "";
+
+  // Calculate max suffix length for overflow case
+  // e.g., "\n\n…他999件あります。\n詳しくはこちら: https://..."
+  const maxOverflowSuffix = `\n\n…他${items.length}件あります。\n詳しくはこちら: ${overflowUrlSuffix}`;
+  const reservedForSuffix = maxOverflowSuffix.length;
+
+  let result = header;
+  let includedCount = 0;
+  const separator = "\n\n";
+
+  for (const item of items) {
+    const nextAddition = (includedCount === 0 ? "" : separator) + item;
+    const potentialLength = result.length + nextAddition.length;
+
+    // Check if adding this item would exceed limit (leaving room for suffix)
+    if (potentialLength + reservedForSuffix > MAX_LINE_CHARS) {
+      break;
+    }
+
+    result += nextAddition;
+    includedCount++;
+  }
+
+  // Add overflow suffix if not all items were included
+  const remainingCount = items.length - includedCount;
+  if (remainingCount > 0) {
+    result += `\n\n…他${remainingCount}件あります。\n詳しくはこちら: ${overflowUrlSuffix}`;
+  }
+
+  // Final safety check - truncate if somehow still over limit
+  if (result.length > MAX_LINE_CHARS) {
+    result = result.slice(0, MAX_LINE_CHARS - 3) + "...";
+  }
+
+  return result;
+}
+
 export async function GET(request: Request) {
   try {
     // 簡易認証（Vercel Cron からのみ叩く想定）
@@ -84,11 +133,12 @@ export async function GET(request: Request) {
 
     if (allNewMessages.length) {
       console.log(`Sending ${allNewMessages.length} new events to LINE...`);
-      // Limit message length for LINE (max 5000 characters)
-      let text = "🍺 今週の新着ビールイベント\n\n" + allNewMessages.slice(0, 5).join("\n\n");
-      if (allNewMessages.length > 5) {
-        text += `\n\n他${allNewMessages.length - 5}件あります。\n詳しくはこちら: ${EVENTS_PAGE_URL}`;
-      }
+      const text = buildLineMessage(
+        "🍺 今週の新着ビールイベント\n\n",
+        allNewMessages,
+        EVENTS_PAGE_URL
+      );
+      console.log(`Message length: ${text.length} characters`);
       await sendLineBroadcast(text);
       console.log("LINE broadcast sent successfully");
     } else {

--- a/src/app/api/cron/sync-events/route.ts
+++ b/src/app/api/cron/sync-events/route.ts
@@ -44,15 +44,13 @@ function buildLineMessage(
     const nextAddition = (includedCount === 0 ? "" : separator) + item;
     const potentialLength = result.length + nextAddition.length;
 
-    // Calculate suffix for remaining items if we stop here
-    const remainingAfterThis = items.length - (includedCount + 1);
-    const overflowSuffix =
-      remainingAfterThis > 0
-        ? `\n\n…他${remainingAfterThis}件あります。\n詳しくはこちら: ${overflowUrlSuffix}`
-        : "";
+    // Calculate suffix for remaining items if we DON'T include this item (i.e., break now)
+    const remainingIfBreak = items.length - includedCount;
+    const suffixIfBreak = `\n\n…他${remainingIfBreak}件あります。\n詳しくはこちら: ${overflowUrlSuffix}`;
 
-    // Check if adding this item + potential suffix would exceed limit
-    if (potentialLength + overflowSuffix.length > MAX_LINE_CHARS) {
+    // Check if adding this item would exceed limit
+    // If it does, we'll break and use suffixIfBreak
+    if (potentialLength + suffixIfBreak.length > MAX_LINE_CHARS) {
       break;
     }
 

--- a/src/app/api/cron/sync-events/route.ts
+++ b/src/app/api/cron/sync-events/route.ts
@@ -22,21 +22,37 @@ function buildLineMessage(
 ): string {
   if (items.length === 0) return "";
 
-  // Calculate max suffix length for overflow case
-  // e.g., "\n\n…他999件あります。\n詳しくはこちら: https://..."
-  const maxOverflowSuffix = `\n\n…他${items.length}件あります。\n詳しくはこちら: ${overflowUrlSuffix}`;
-  const reservedForSuffix = maxOverflowSuffix.length;
+  const separator = "\n\n";
 
+  // First, try to include all items without overflow suffix
+  let fullMessage = header;
+  for (let i = 0; i < items.length; i++) {
+    fullMessage += (i === 0 ? "" : separator) + items[i];
+  }
+
+  // If everything fits, return as-is
+  if (fullMessage.length <= MAX_LINE_CHARS) {
+    return fullMessage;
+  }
+
+  // Otherwise, we need to truncate and add overflow suffix
+  // Build message item by item, reserving space for suffix
   let result = header;
   let includedCount = 0;
-  const separator = "\n\n";
 
   for (const item of items) {
     const nextAddition = (includedCount === 0 ? "" : separator) + item;
     const potentialLength = result.length + nextAddition.length;
 
-    // Check if adding this item would exceed limit (leaving room for suffix)
-    if (potentialLength + reservedForSuffix > MAX_LINE_CHARS) {
+    // Calculate suffix for remaining items if we stop here
+    const remainingAfterThis = items.length - (includedCount + 1);
+    const overflowSuffix =
+      remainingAfterThis > 0
+        ? `\n\n…他${remainingAfterThis}件あります。\n詳しくはこちら: ${overflowUrlSuffix}`
+        : "";
+
+    // Check if adding this item + potential suffix would exceed limit
+    if (potentialLength + overflowSuffix.length > MAX_LINE_CHARS) {
       break;
     }
 


### PR DESCRIPTION
## Summary

- **LINE通知メッセージの文字数制限対応**: LINE Messaging APIの5000文字制限に対応
- **buildLineMessage関数の追加**: イベント数が多い場合に適切にトランケートし、「他N件あります」と残り件数を表示
- **Webページへの誘導**: 制限を超えた場合はイベント一覧ページへのリンクを追加

## 変更内容

| 変更点 | 説明 |
|--------|------|
| 文字数制限対応 | 5000文字を超えないようにメッセージを構築 |
| オーバーフロー表示 | 「…他N件あります」と残り件数を表示 |
| Webリンク追加 | 詳細はイベント一覧ページで確認できるよう誘導 |

## 技術詳細

```typescript
function buildLineMessage(
  header: string,
  items: string[],
  overflowUrlSuffix: string
): string
```

- 各イベントを順次追加し、5000文字を超える前に停止
- 残りのイベント数を計算して「…他N件あります」を追加
- 最終的な安全チェックとしてトランケート処理も実装

## Test plan

- [ ] 大量のイベント（20件以上）がある場合にメッセージが5000文字以内に収まることを確認
- [ ] オーバーフロー時に「他N件あります」が正しく表示されることを確認
- [ ] イベント一覧ページへのリンクが正しく追加されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
- LINE通知のメッセージが5000文字を超える場合、自動的に制限されるようになりました。超過時には残りのアイテムを示す情報と参照リンクが自動的に追加されます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->