### PR TITLE
fix: Handle iCal recurring events with RECURRENCE-ID

### DIFF
--- a/src/server/crawlers/alwaysLoveBeerCalendar.ts
+++ b/src/server/crawlers/alwaysLoveBeerCalendar.ts
@@ -108,6 +108,7 @@ function parseICalEvents(icalText: string): CrawledItem[] {
       let dtstart = "";
       let description = "";
       let uid = "";
+      let recurrenceId = "";
 
       for (const line of lines) {
         const trimmed = line.trim();
@@ -124,10 +125,20 @@ function parseICalEvents(icalText: string): CrawledItem[] {
           description = trimmed.substring(12).trim();
         } else if (trimmed.startsWith("UID:")) {
           uid = trimmed.substring(4).trim();
+        } else if (trimmed.startsWith("RECURRENCE-ID")) {
+          // Handle RECURRENCE-ID:20240101 and RECURRENCE-ID;TZID=...:...
+          const colonIndex = trimmed.indexOf(":");
+          if (colonIndex > 0) {
+            recurrenceId = trimmed.substring(colonIndex + 1).trim();
+          }
         }
       }
 
       if (!summary || !uid) continue;
+
+      // Create unique external ID by combining UID and RECURRENCE-ID (if present)
+      // This ensures recurring event instances are treated as separate events
+      const externalId = recurrenceId ? `${uid}::${recurrenceId}` : uid;
 
       // Extract URL from description
       let url = extractUrlFromDescription(description);
@@ -150,7 +161,7 @@ function parseICalEvents(icalText: string): CrawledItem[] {
       }
 
       items.push({
-        externalId: uid,
+        externalId,
         title: summary,
         url,
         sourceId: SOURCE_ID,

--- a/src/server/crawlers/beergirlCalendar.ts
+++ b/src/server/crawlers/beergirlCalendar.ts
@@ -88,6 +88,7 @@ function parseICalEvents(icalText: string): CrawledItem[] {
       let dtstart = "";
       let description = "";
       let uid = "";
+      let recurrenceId = "";
 
       for (const line of lines) {
         const trimmed = line.trim();
@@ -104,10 +105,20 @@ function parseICalEvents(icalText: string): CrawledItem[] {
           description = trimmed.substring(12).trim();
         } else if (trimmed.startsWith("UID:")) {
           uid = trimmed.substring(4).trim();
+        } else if (trimmed.startsWith("RECURRENCE-ID")) {
+          // Handle RECURRENCE-ID:20240101 and RECURRENCE-ID;TZID=...:...
+          const colonIndex = trimmed.indexOf(":");
+          if (colonIndex > 0) {
+            recurrenceId = trimmed.substring(colonIndex + 1).trim();
+          }
         }
       }
 
       if (!summary || !uid) continue;
+
+      // Create unique external ID by combining UID and RECURRENCE-ID (if present)
+      // This ensures recurring event instances are treated as separate events
+      const externalId = recurrenceId ? `${uid}::${recurrenceId}` : uid;
 
       // Extract URL from description (format: <a href="URL">...</a>)
       let url = "";
@@ -136,7 +147,7 @@ function parseICalEvents(icalText: string): CrawledItem[] {
       }
 
       items.push({
-        externalId: uid,
+        externalId,
         title: summary,
         url,
         sourceId: SOURCE_ID,


### PR DESCRIPTION
## Summary
- Fix duplicate event handling for iCal recurring events
- Recurring events share the same UID but use RECURRENCE-ID to identify instances
- Now combining UID + RECURRENCE-ID to create unique external IDs

## Problem
Previously, all instances of recurring events would collapse into a single event record because they share the same UID. Only the last processed instance would remain.

## Solution
When parsing iCal events, check for RECURRENCE-ID and combine it with UID to create a unique identifier: `${uid}::${recurrenceId}`

## Test plan
- [ ] Build passes
- [ ] Recurring events from calendar are stored as separate records

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * カレンダーの繰り返しイベント（定期イベント）の処理が改善されました。複数のカレンダーソースにおいて、繰り返しイベントの各インスタンスが個別のイベントとして正しく扱われるようになりました。これにより、イベント情報の正確性が向上します。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->