### PR TITLE
feat: Multi-day events, carousel controls, and improved duplicate detection

### DIFF
--- a/src/app/components/PickupCarousel.tsx
+++ b/src/app/components/PickupCarousel.tsx
@@ -12,7 +12,7 @@ export function PickupCarousel({ children, speed = 30 }: PickupCarouselProps) {
   const contentRef = useRef<HTMLDivElement>(null);
   const [shouldAnimate, setShouldAnimate] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
-  const [isDragging, setIsDragging] = useState(false);
+  const [isInteracting, setIsInteracting] = useState(false);
   const dragStartX = useRef(0);
   const scrollStartX = useRef(0);
 
@@ -38,44 +38,48 @@ export function PickupCarousel({ children, speed = 30 }: PickupCarouselProps) {
   // Mouse drag handlers
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     if (!shouldAnimate) return;
-    setIsDragging(true);
+    e.preventDefault();
+    setIsInteracting(true);
     setIsPaused(true);
     dragStartX.current = e.clientX;
     scrollStartX.current = wrapperRef.current?.scrollLeft || 0;
   }, [shouldAnimate]);
 
   const handleMouseMove = useCallback((e: React.MouseEvent) => {
-    if (!isDragging || !wrapperRef.current) return;
+    if (!isInteracting || !wrapperRef.current) return;
+    e.preventDefault();
     const diff = dragStartX.current - e.clientX;
     wrapperRef.current.scrollLeft = scrollStartX.current + diff;
-  }, [isDragging]);
+  }, [isInteracting]);
 
   const handleMouseUp = useCallback(() => {
-    setIsDragging(false);
+    setIsInteracting(false);
     setIsPaused(false);
   }, []);
 
   const handleMouseLeave = useCallback(() => {
-    setIsDragging(false);
+    setIsInteracting(false);
     setIsPaused(false);
   }, []);
 
   // Touch handlers for mobile swipe
   const handleTouchStart = useCallback((e: React.TouchEvent) => {
     if (!shouldAnimate) return;
+    setIsInteracting(true);
     setIsPaused(true);
     dragStartX.current = e.touches[0]?.clientX || 0;
     scrollStartX.current = wrapperRef.current?.scrollLeft || 0;
   }, [shouldAnimate]);
 
   const handleTouchMove = useCallback((e: React.TouchEvent) => {
-    if (!wrapperRef.current) return;
+    if (!isInteracting || !wrapperRef.current) return;
     const touchX = e.touches[0]?.clientX || 0;
     const diff = dragStartX.current - touchX;
     wrapperRef.current.scrollLeft = scrollStartX.current + diff;
-  }, []);
+  }, [isInteracting]);
 
   const handleTouchEnd = useCallback(() => {
+    setIsInteracting(false);
     setIsPaused(false);
   }, []);
 
@@ -92,11 +96,17 @@ export function PickupCarousel({ children, speed = 30 }: PickupCarouselProps) {
     }
   }, [shouldAnimate]);
 
-  // Common wrapper that always has refs attached
+  // When animating, use CSS animation; when interacting, use native scroll
+  const useAnimation = shouldAnimate && !isInteracting;
+
   return (
     <div
       ref={wrapperRef}
-      className={shouldAnimate ? "marquee-container -mx-4 overflow-x-auto scrollbar-hide cursor-grab active:cursor-grabbing" : "overflow-x-auto pb-2 -mx-4 px-4 scrollbar-hide"}
+      className={`-mx-4 scrollbar-hide ${
+        shouldAnimate
+          ? "marquee-container overflow-x-auto cursor-grab active:cursor-grabbing"
+          : "overflow-x-auto pb-2 px-4"
+      }`}
       onMouseDown={handleMouseDown}
       onMouseMove={handleMouseMove}
       onMouseUp={handleMouseUp}
@@ -109,12 +119,8 @@ export function PickupCarousel({ children, speed = 30 }: PickupCarouselProps) {
     >
       <div
         ref={contentRef}
-        className={
-          shouldAnimate
-            ? "flex gap-3 md:gap-4 animate-scroll-left px-4"
-            : "flex gap-3 md:gap-4"
-        }
-        style={shouldAnimate ? {
+        className={`flex gap-3 md:gap-4 ${useAnimation ? "animate-scroll-left" : ""} ${shouldAnimate ? "px-4" : ""}`}
+        style={useAnimation ? {
           animationDuration: `${speed}s`,
           animationPlayState: isPaused ? "paused" : "running"
         } : undefined}

--- a/src/server/utils/duplicateDetector.ts
+++ b/src/server/utils/duplicateDetector.ts
@@ -153,14 +153,19 @@ export function calculateDuplicateScore(
   // Same source = not considered duplicate (already deduped within source)
   if (event1.sourceId === event2.sourceId) return 0;
 
-  // If one title contains the other (after normalization), high match
+  // If one title contains the other (after normalization), check dates
   if (containsOther(event1.title, event2.title)) {
-    // If dates also match, definitely duplicate
+    // If dates match, definitely duplicate
     if (isSameDate(event1.eventDate, event2.eventDate)) {
       return 0.9;
     }
-    // Even without date, containment is a strong signal
-    return 0.7;
+    // If one date is missing, still consider it a likely duplicate
+    if (!event1.eventDate || !event2.eventDate) {
+      return 0.7;
+    }
+    // Both dates present but different - probably different events (annual, different city)
+    // Return low score to avoid false positives
+    return 0.4;
   }
 
   // Calculate term similarity

--- a/src/server/utils/duplicateDetector.ts
+++ b/src/server/utils/duplicateDetector.ts
@@ -21,10 +21,14 @@ function normalizeText(text: string): string {
     .toLowerCase()
     .replace(/[\s\u3000]+/g, " ") // Normalize whitespace (including Japanese space)
     .replace(/[【】「」『』（）()［］\[\]]/g, "") // Remove brackets
-    .replace(/[、。！？!?,.]/g, "") // Remove punctuation
+    .replace(/[、。！？!?,.：:@＠]/g, "") // Remove punctuation
     .replace(/第(\d+)回/g, "$1") // Normalize "第N回" to just number
     .replace(/ビアフェス|ビールフェス|ビールフェスティバル|beer\s*fest(?:ival)?/gi, "ビアフェス")
     .replace(/オクトーバーフェスト|oktoberfest/gi, "オクトーバーフェスト")
+    // Remove location prefixes like "神奈川：" or "東京："
+    .replace(/^(東京|神奈川|大阪|愛知|福岡|北海道|埼玉|千葉|兵庫|京都|静岡|広島|宮城)[：:]?\s*/g, "")
+    // Remove venue suffixes like "@横浜大さん橋ホール"
+    .replace(/@.+$/, "")
     .trim();
 }
 
@@ -51,11 +55,26 @@ function extractKeyTerms(title: string): Set<string> {
   const eventTypes = [
     "ビアフェス", "ビアガーデン", "オクトーバーフェスト", "クラフトビール",
     "地ビール", "ブルワリー", "醸造", "試飲", "飲み比べ", "タップ",
-    "フェスティバル", "フェス", "祭", "マルシェ", "フェア"
+    "フェスティバル", "フェス", "祭", "マルシェ", "フェア",
+    // English event names
+    "brewers cup", "ブルワーズカップ", "japan brewers", "beer week",
+    "craft beer", "beer festival", "beer garden"
   ];
   for (const type of eventTypes) {
     if (normalized.includes(type)) {
       terms.add(type);
+    }
+  }
+
+  // Extract well-known event names as a whole
+  const knownEvents = [
+    "japan brewers cup", "ジャパンブルワーズカップ",
+    "けやきひろば", "大江戸ビール祭り", "よこはまビール祭り",
+    "ビアフェス信越", "ビアフェス横浜", "クラフトビア横浜"
+  ];
+  for (const event of knownEvents) {
+    if (normalized.includes(event)) {
+      terms.add(event);
     }
   }
 
@@ -114,6 +133,16 @@ function isSameDate(date1?: Date, date2?: Date): boolean {
 }
 
 /**
+ * Check if one normalized title contains the other (substring match)
+ */
+function containsOther(title1: string, title2: string): boolean {
+  const norm1 = normalizeText(title1);
+  const norm2 = normalizeText(title2);
+  // One title is substantially contained in the other
+  return norm1.includes(norm2) || norm2.includes(norm1);
+}
+
+/**
  * Check if two events are likely duplicates
  * Returns a confidence score between 0 and 1
  */
@@ -123,6 +152,16 @@ export function calculateDuplicateScore(
 ): number {
   // Same source = not considered duplicate (already deduped within source)
   if (event1.sourceId === event2.sourceId) return 0;
+
+  // If one title contains the other (after normalization), high match
+  if (containsOther(event1.title, event2.title)) {
+    // If dates also match, definitely duplicate
+    if (isSameDate(event1.eventDate, event2.eventDate)) {
+      return 0.9;
+    }
+    // Even without date, containment is a strong signal
+    return 0.7;
+  }
 
   // Calculate term similarity
   const terms1 = extractKeyTerms(event1.title);


### PR DESCRIPTION
## Summary
- Add `eventEndDate` field to Event model for multi-day events (e.g., "1/24-26")
- Add user interaction controls to PickupCarousel (hover pause, mouse drag, touch swipe, wheel scroll)
- Improve duplicate detection to handle events with location prefixes and venue suffixes
- Add detailed crawl result logging (new/updated/skipped counts)
- Add display-time duplicate removal on the main page

## Changes
- **Prisma schema**: Add `eventEndDate` column with migration
- **Crawlers**: Parse DTEND from iCal for multi-day events
- **date-utils**: Update `getEventStatusJST` to handle multi-day events (show "今日!" for ongoing events)
- **PickupCarousel**: Add mouse drag, touch swipe, wheel scroll handlers
- **duplicateDetector**: Add substring matching, strip prefixes/suffixes for better matching
- **page.tsx**: Remove duplicates at display time using `removeDuplicates`

## Test plan
- [ ] Verify multi-day events display date range (e.g., "1/24-26")
- [ ] Verify carousel pauses on hover and resumes when mouse leaves
- [ ] Verify carousel can be dragged/swiped by user
- [ ] Verify "JAPAN BREWERS CUP" no longer shows as duplicate
- [ ] Verify crawl logs show new/updated/skipped counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)