### PR TITLE
feat: Add LINE bot promotion banner

### DIFF
--- a/src/app/components/LineBotBanner.tsx
+++ b/src/app/components/LineBotBanner.tsx
@@ -5,66 +5,52 @@ const LINE_ADD_FRIEND_URL = `https://line.me/R/ti/p/${LINE_OFFICIAL_ACCOUNT_ID}`
 
 export function LineBotBanner() {
   return (
-    <section className="py-6 md:py-10">
-      <div className="max-w-4xl mx-auto px-4">
+    <section className="py-4 md:py-6">
+      <div className="max-w-2xl mx-auto px-4">
         <a
           href={LINE_ADD_FRIEND_URL}
           target="_blank"
           rel="noopener noreferrer"
-          className="block group"
+          className="flex items-center justify-between gap-3 px-4 py-3 md:px-5 md:py-3.5 bg-white border border-gray-200 rounded-xl hover:border-[#06C755]/30 hover:bg-green-50/30 transition-all group"
         >
-          <div className="relative overflow-hidden rounded-2xl md:rounded-3xl bg-gradient-to-r from-[#06C755] to-[#00B900] p-5 md:p-8 shadow-lg shadow-green-500/20 hover:shadow-xl hover:shadow-green-500/30 transition-all duration-300 hover:scale-[1.02]">
-            {/* Background decoration */}
-            <div className="absolute inset-0 overflow-hidden pointer-events-none">
-              <div className="absolute -top-10 -right-10 w-32 h-32 md:w-48 md:h-48 bg-white/10 rounded-full blur-2xl" />
-              <div className="absolute -bottom-10 -left-10 w-24 h-24 md:w-40 md:h-40 bg-white/10 rounded-full blur-2xl" />
+          <div className="flex items-center gap-3">
+            {/* LINE icon */}
+            <div className="flex-shrink-0 w-9 h-9 md:w-10 md:h-10 rounded-lg bg-[#06C755] flex items-center justify-center">
+              <svg
+                viewBox="0 0 24 24"
+                className="w-5 h-5 md:w-6 md:h-6"
+                fill="white"
+              >
+                <path d="M19.365 9.863c.349 0 .63.285.63.631 0 .345-.281.63-.63.63H17.61v1.125h1.755c.349 0 .63.283.63.63 0 .344-.281.629-.63.629h-2.386c-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63h2.386c.346 0 .627.285.627.63 0 .349-.281.63-.63.63H17.61v1.125h1.755zm-3.855 3.016c0 .27-.174.51-.432.596-.064.021-.133.031-.199.031-.211 0-.391-.09-.51-.25l-2.443-3.317v2.94c0 .344-.279.629-.631.629-.346 0-.626-.285-.626-.629V8.108c0-.27.173-.51.43-.595.06-.023.136-.033.194-.033.195 0 .375.104.495.254l2.462 3.33V8.108c0-.345.282-.63.63-.63.345 0 .63.285.63.63v4.771zm-5.741 0c0 .344-.282.629-.631.629-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63.346 0 .628.285.628.63v4.771zm-2.466.629H4.917c-.345 0-.63-.285-.63-.629V8.108c0-.345.285-.63.63-.63.348 0 .63.285.63.63v4.141h1.756c.348 0 .629.283.629.63 0 .344-.282.629-.629.629M24 10.314C24 4.943 18.615.572 12 .572S0 4.943 0 10.314c0 4.811 4.27 8.842 10.035 9.608.391.082.923.258 1.058.59.12.301.079.766.038 1.08l-.164 1.02c-.045.301-.24 1.186 1.049.645 1.291-.539 6.916-4.078 9.436-6.975C23.176 14.393 24 12.458 24 10.314" />
+              </svg>
             </div>
 
-            <div className="relative flex flex-col md:flex-row items-center gap-4 md:gap-6">
-              {/* LINE icon */}
-              <div className="flex-shrink-0 w-16 h-16 md:w-20 md:h-20 rounded-2xl bg-white flex items-center justify-center shadow-lg group-hover:scale-110 transition-transform duration-300">
-                <svg
-                  viewBox="0 0 24 24"
-                  className="w-10 h-10 md:w-12 md:h-12"
-                  fill="#06C755"
-                >
-                  <path d="M19.365 9.863c.349 0 .63.285.63.631 0 .345-.281.63-.63.63H17.61v1.125h1.755c.349 0 .63.283.63.63 0 .344-.281.629-.63.629h-2.386c-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63h2.386c.346 0 .627.285.627.63 0 .349-.281.63-.63.63H17.61v1.125h1.755zm-3.855 3.016c0 .27-.174.51-.432.596-.064.021-.133.031-.199.031-.211 0-.391-.09-.51-.25l-2.443-3.317v2.94c0 .344-.279.629-.631.629-.346 0-.626-.285-.626-.629V8.108c0-.27.173-.51.43-.595.06-.023.136-.033.194-.033.195 0 .375.104.495.254l2.462 3.33V8.108c0-.345.282-.63.63-.63.345 0 .63.285.63.63v4.771zm-5.741 0c0 .344-.282.629-.631.629-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63.346 0 .628.285.628.63v4.771zm-2.466.629H4.917c-.345 0-.63-.285-.63-.629V8.108c0-.345.285-.63.63-.63.348 0 .63.285.63.63v4.141h1.756c.348 0 .629.283.629.63 0 .344-.282.629-.629.629M24 10.314C24 4.943 18.615.572 12 .572S0 4.943 0 10.314c0 4.811 4.27 8.842 10.035 9.608.391.082.923.258 1.058.59.12.301.079.766.038 1.08l-.164 1.02c-.045.301-.24 1.186 1.049.645 1.291-.539 6.916-4.078 9.436-6.975C23.176 14.393 24 12.458 24 10.314" />
-                </svg>
-              </div>
-
-              {/* Content */}
-              <div className="flex-1 text-center md:text-left">
-                <h3 className="text-xl md:text-2xl font-bold text-white mb-1 md:mb-2">
-                  LINE公式アカウント
-                </h3>
-                <p className="text-white/90 text-sm md:text-base mb-3 md:mb-0">
-                  新着イベント情報をLINEでお届け！
-                  <br className="hidden md:block" />
-                  <span className="hidden md:inline">毎日自動で最新のビールイベントをチェック。</span>
-                  <span className="md:hidden">毎日最新イベントをお届けします。</span>
-                </p>
-              </div>
-
-              {/* CTA button */}
-              <div className="flex-shrink-0">
-                <span className="inline-flex items-center gap-2 px-5 py-2.5 md:px-6 md:py-3 bg-white text-[#06C755] font-bold rounded-full shadow-lg group-hover:shadow-xl transition-all duration-300">
-                  <span className="text-sm md:text-base">友だち追加</span>
-                  <svg
-                    className="w-4 h-4 md:w-5 md:h-5 group-hover:translate-x-1 transition-transform"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M13 7l5 5m0 0l-5 5m5-5H6"
-                    />
-                  </svg>
-                </span>
-              </div>
+            {/* Content */}
+            <div>
+              <p className="text-sm md:text-base text-gray-700 font-medium">
+                新着イベントをLINEでお届け
+              </p>
+              <p className="text-xs text-gray-500 hidden sm:block">
+                友だち追加で通知を受け取る
+              </p>
             </div>
+          </div>
+
+          {/* Arrow */}
+          <div className="flex-shrink-0 text-gray-400 group-hover:text-[#06C755] transition-colors">
+            <svg
+              className="w-5 h-5 group-hover:translate-x-0.5 transition-transform"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 5l7 7-7 7"
+              />
+            </svg>
           </div>
         </a>
       </div>
@@ -79,12 +65,12 @@ export function LineBotFooterLink() {
       href={LINE_ADD_FRIEND_URL}
       target="_blank"
       rel="noopener noreferrer"
-      className="inline-flex items-center gap-2 px-4 py-2 bg-[#06C755] hover:bg-[#05B34C] text-white text-sm font-medium rounded-full transition-all hover:scale-105 shadow-md shadow-green-500/20"
+      className="inline-flex items-center gap-2 px-3 py-1.5 bg-[#06C755] hover:bg-[#05B34C] text-white text-xs md:text-sm font-medium rounded-full transition-all hover:scale-105"
     >
-      <svg viewBox="0 0 24 24" className="w-4 h-4" fill="currentColor">
+      <svg viewBox="0 0 24 24" className="w-3.5 h-3.5" fill="currentColor">
         <path d="M19.365 9.863c.349 0 .63.285.63.631 0 .345-.281.63-.63.63H17.61v1.125h1.755c.349 0 .63.283.63.63 0 .344-.281.629-.63.629h-2.386c-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63h2.386c.346 0 .627.285.627.63 0 .349-.281.63-.63.63H17.61v1.125h1.755zm-3.855 3.016c0 .27-.174.51-.432.596-.064.021-.133.031-.199.031-.211 0-.391-.09-.51-.25l-2.443-3.317v2.94c0 .344-.279.629-.631.629-.346 0-.626-.285-.626-.629V8.108c0-.27.173-.51.43-.595.06-.023.136-.033.194-.033.195 0 .375.104.495.254l2.462 3.33V8.108c0-.345.282-.63.63-.63.345 0 .63.285.63.63v4.771zm-5.741 0c0 .344-.282.629-.631.629-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63.346 0 .628.285.628.63v4.771zm-2.466.629H4.917c-.345 0-.63-.285-.63-.629V8.108c0-.345.285-.63.63-.63.348 0 .63.285.63.63v4.141h1.756c.348 0 .629.283.629.63 0 .344-.282.629-.629.629M24 10.314C24 4.943 18.615.572 12 .572S0 4.943 0 10.314c0 4.811 4.27 8.842 10.035 9.608.391.082.923.258 1.058.59.12.301.079.766.038 1.08l-.164 1.02c-.045.301-.24 1.186 1.049.645 1.291-.539 6.916-4.078 9.436-6.975C23.176 14.393 24 12.458 24 10.314" />
       </svg>
-      LINE通知を受け取る
+      LINE通知
     </a>
   );
 }

--- a/src/app/components/LineBotBanner.tsx
+++ b/src/app/components/LineBotBanner.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+const LINE_OFFICIAL_ACCOUNT_ID = "@472staqy";
+const LINE_ADD_FRIEND_URL = `https://line.me/R/ti/p/${LINE_OFFICIAL_ACCOUNT_ID}`;
+
+export function LineBotBanner() {
+  return (
+    <section className="py-6 md:py-10">
+      <div className="max-w-4xl mx-auto px-4">
+        <a
+          href={LINE_ADD_FRIEND_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block group"
+        >
+          <div className="relative overflow-hidden rounded-2xl md:rounded-3xl bg-gradient-to-r from-[#06C755] to-[#00B900] p-5 md:p-8 shadow-lg shadow-green-500/20 hover:shadow-xl hover:shadow-green-500/30 transition-all duration-300 hover:scale-[1.02]">
+            {/* Background decoration */}
+            <div className="absolute inset-0 overflow-hidden pointer-events-none">
+              <div className="absolute -top-10 -right-10 w-32 h-32 md:w-48 md:h-48 bg-white/10 rounded-full blur-2xl" />
+              <div className="absolute -bottom-10 -left-10 w-24 h-24 md:w-40 md:h-40 bg-white/10 rounded-full blur-2xl" />
+            </div>
+
+            <div className="relative flex flex-col md:flex-row items-center gap-4 md:gap-6">
+              {/* LINE icon */}
+              <div className="flex-shrink-0 w-16 h-16 md:w-20 md:h-20 rounded-2xl bg-white flex items-center justify-center shadow-lg group-hover:scale-110 transition-transform duration-300">
+                <svg
+                  viewBox="0 0 24 24"
+                  className="w-10 h-10 md:w-12 md:h-12"
+                  fill="#06C755"
+                >
+                  <path d="M19.365 9.863c.349 0 .63.285.63.631 0 .345-.281.63-.63.63H17.61v1.125h1.755c.349 0 .63.283.63.63 0 .344-.281.629-.63.629h-2.386c-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63h2.386c.346 0 .627.285.627.63 0 .349-.281.63-.63.63H17.61v1.125h1.755zm-3.855 3.016c0 .27-.174.51-.432.596-.064.021-.133.031-.199.031-.211 0-.391-.09-.51-.25l-2.443-3.317v2.94c0 .344-.279.629-.631.629-.346 0-.626-.285-.626-.629V8.108c0-.27.173-.51.43-.595.06-.023.136-.033.194-.033.195 0 .375.104.495.254l2.462 3.33V8.108c0-.345.282-.63.63-.63.345 0 .63.285.63.63v4.771zm-5.741 0c0 .344-.282.629-.631.629-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63.346 0 .628.285.628.63v4.771zm-2.466.629H4.917c-.345 0-.63-.285-.63-.629V8.108c0-.345.285-.63.63-.63.348 0 .63.285.63.63v4.141h1.756c.348 0 .629.283.629.63 0 .344-.282.629-.629.629M24 10.314C24 4.943 18.615.572 12 .572S0 4.943 0 10.314c0 4.811 4.27 8.842 10.035 9.608.391.082.923.258 1.058.59.12.301.079.766.038 1.08l-.164 1.02c-.045.301-.24 1.186 1.049.645 1.291-.539 6.916-4.078 9.436-6.975C23.176 14.393 24 12.458 24 10.314" />
+                </svg>
+              </div>
+
+              {/* Content */}
+              <div className="flex-1 text-center md:text-left">
+                <h3 className="text-xl md:text-2xl font-bold text-white mb-1 md:mb-2">
+                  LINE公式アカウント
+                </h3>
+                <p className="text-white/90 text-sm md:text-base mb-3 md:mb-0">
+                  新着イベント情報をLINEでお届け！
+                  <br className="hidden md:block" />
+                  <span className="hidden md:inline">毎日自動で最新のビールイベントをチェック。</span>
+                  <span className="md:hidden">毎日最新イベントをお届けします。</span>
+                </p>
+              </div>
+
+              {/* CTA button */}
+              <div className="flex-shrink-0">
+                <span className="inline-flex items-center gap-2 px-5 py-2.5 md:px-6 md:py-3 bg-white text-[#06C755] font-bold rounded-full shadow-lg group-hover:shadow-xl transition-all duration-300">
+                  <span className="text-sm md:text-base">友だち追加</span>
+                  <svg
+                    className="w-4 h-4 md:w-5 md:h-5 group-hover:translate-x-1 transition-transform"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M13 7l5 5m0 0l-5 5m5-5H6"
+                    />
+                  </svg>
+                </span>
+              </div>
+            </div>
+          </div>
+        </a>
+      </div>
+    </section>
+  );
+}
+
+// Compact version for footer
+export function LineBotFooterLink() {
+  return (
+    <a
+      href={LINE_ADD_FRIEND_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-2 px-4 py-2 bg-[#06C755] hover:bg-[#05B34C] text-white text-sm font-medium rounded-full transition-all hover:scale-105 shadow-md shadow-green-500/20"
+    >
+      <svg viewBox="0 0 24 24" className="w-4 h-4" fill="currentColor">
+        <path d="M19.365 9.863c.349 0 .63.285.63.631 0 .345-.281.63-.63.63H17.61v1.125h1.755c.349 0 .63.283.63.63 0 .344-.281.629-.63.629h-2.386c-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63h2.386c.346 0 .627.285.627.63 0 .349-.281.63-.63.63H17.61v1.125h1.755zm-3.855 3.016c0 .27-.174.51-.432.596-.064.021-.133.031-.199.031-.211 0-.391-.09-.51-.25l-2.443-3.317v2.94c0 .344-.279.629-.631.629-.346 0-.626-.285-.626-.629V8.108c0-.27.173-.51.43-.595.06-.023.136-.033.194-.033.195 0 .375.104.495.254l2.462 3.33V8.108c0-.345.282-.63.63-.63.345 0 .63.285.63.63v4.771zm-5.741 0c0 .344-.282.629-.631.629-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63.346 0 .628.285.628.63v4.771zm-2.466.629H4.917c-.345 0-.63-.285-.63-.629V8.108c0-.345.285-.63.63-.63.348 0 .63.285.63.63v4.141h1.756c.348 0 .629.283.629.63 0 .344-.282.629-.629.629M24 10.314C24 4.943 18.615.572 12 .572S0 4.943 0 10.314c0 4.811 4.27 8.842 10.035 9.608.391.082.923.258 1.058.59.12.301.079.766.038 1.08l-.164 1.02c-.045.301-.24 1.186 1.049.645 1.291-.539 6.916-4.078 9.436-6.975C23.176 14.393 24 12.458 24 10.314" />
+      </svg>
+      LINE通知を受け取る
+    </a>
+  );
+}

--- a/src/app/components/LineBotBanner.tsx
+++ b/src/app/components/LineBotBanner.tsx
@@ -1,60 +1,58 @@
 "use client";
 
-const LINE_OFFICIAL_ACCOUNT_ID = "@472staqy";
+const LINE_OFFICIAL_ACCOUNT_ID = "@472satqy";
 const LINE_ADD_FRIEND_URL = `https://line.me/R/ti/p/${LINE_OFFICIAL_ACCOUNT_ID}`;
 
 export function LineBotBanner() {
   return (
-    <section className="py-4 md:py-6">
-      <div className="max-w-2xl mx-auto px-4">
-        <a
-          href={LINE_ADD_FRIEND_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex items-center justify-between gap-3 px-4 py-3 md:px-5 md:py-3.5 bg-white border border-gray-200 rounded-xl hover:border-[#06C755]/30 hover:bg-green-50/30 transition-all group"
-        >
-          <div className="flex items-center gap-3">
-            {/* LINE icon */}
-            <div className="flex-shrink-0 w-9 h-9 md:w-10 md:h-10 rounded-lg bg-[#06C755] flex items-center justify-center">
-              <svg
-                viewBox="0 0 24 24"
-                className="w-5 h-5 md:w-6 md:h-6"
-                fill="white"
-              >
-                <path d="M19.365 9.863c.349 0 .63.285.63.631 0 .345-.281.63-.63.63H17.61v1.125h1.755c.349 0 .63.283.63.63 0 .344-.281.629-.63.629h-2.386c-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63h2.386c.346 0 .627.285.627.63 0 .349-.281.63-.63.63H17.61v1.125h1.755zm-3.855 3.016c0 .27-.174.51-.432.596-.064.021-.133.031-.199.031-.211 0-.391-.09-.51-.25l-2.443-3.317v2.94c0 .344-.279.629-.631.629-.346 0-.626-.285-.626-.629V8.108c0-.27.173-.51.43-.595.06-.023.136-.033.194-.033.195 0 .375.104.495.254l2.462 3.33V8.108c0-.345.282-.63.63-.63.345 0 .63.285.63.63v4.771zm-5.741 0c0 .344-.282.629-.631.629-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63.346 0 .628.285.628.63v4.771zm-2.466.629H4.917c-.345 0-.63-.285-.63-.629V8.108c0-.345.285-.63.63-.63.348 0 .63.285.63.63v4.141h1.756c.348 0 .629.283.629.63 0 .344-.282.629-.629.629M24 10.314C24 4.943 18.615.572 12 .572S0 4.943 0 10.314c0 4.811 4.27 8.842 10.035 9.608.391.082.923.258 1.058.59.12.301.079.766.038 1.08l-.164 1.02c-.045.301-.24 1.186 1.049.645 1.291-.539 6.916-4.078 9.436-6.975C23.176 14.393 24 12.458 24 10.314" />
-              </svg>
-            </div>
-
-            {/* Content */}
-            <div>
-              <p className="text-sm md:text-base text-gray-700 font-medium">
-                新着イベントをLINEでお届け
-              </p>
-              <p className="text-xs text-gray-500 hidden sm:block">
-                友だち追加で通知を受け取る
-              </p>
-            </div>
-          </div>
-
-          {/* Arrow */}
-          <div className="flex-shrink-0 text-gray-400 group-hover:text-[#06C755] transition-colors">
+    <div className="max-w-xl mx-auto mt-5 md:mt-8">
+      <a
+        href={LINE_ADD_FRIEND_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center justify-between gap-3 px-4 py-3 md:px-5 md:py-3.5 bg-white border border-gray-200 rounded-xl hover:border-[#06C755]/30 hover:bg-green-50/30 transition-all group"
+      >
+        <div className="flex items-center gap-3">
+          {/* LINE icon */}
+          <div className="flex-shrink-0 w-9 h-9 md:w-10 md:h-10 rounded-lg bg-[#06C755] flex items-center justify-center">
             <svg
-              className="w-5 h-5 group-hover:translate-x-0.5 transition-transform"
-              fill="none"
-              stroke="currentColor"
               viewBox="0 0 24 24"
+              className="w-5 h-5 md:w-6 md:h-6"
+              fill="white"
             >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M9 5l7 7-7 7"
-              />
+              <path d="M19.365 9.863c.349 0 .63.285.63.631 0 .345-.281.63-.63.63H17.61v1.125h1.755c.349 0 .63.283.63.63 0 .344-.281.629-.63.629h-2.386c-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63h2.386c.346 0 .627.285.627.63 0 .349-.281.63-.63.63H17.61v1.125h1.755zm-3.855 3.016c0 .27-.174.51-.432.596-.064.021-.133.031-.199.031-.211 0-.391-.09-.51-.25l-2.443-3.317v2.94c0 .344-.279.629-.631.629-.346 0-.626-.285-.626-.629V8.108c0-.27.173-.51.43-.595.06-.023.136-.033.194-.033.195 0 .375.104.495.254l2.462 3.33V8.108c0-.345.282-.63.63-.63.345 0 .63.285.63.63v4.771zm-5.741 0c0 .344-.282.629-.631.629-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63.346 0 .628.285.628.63v4.771zm-2.466.629H4.917c-.345 0-.63-.285-.63-.629V8.108c0-.345.285-.63.63-.63.348 0 .63.285.63.63v4.141h1.756c.348 0 .629.283.629.63 0 .344-.282.629-.629.629M24 10.314C24 4.943 18.615.572 12 .572S0 4.943 0 10.314c0 4.811 4.27 8.842 10.035 9.608.391.082.923.258 1.058.59.12.301.079.766.038 1.08l-.164 1.02c-.045.301-.24 1.186 1.049.645 1.291-.539 6.916-4.078 9.436-6.975C23.176 14.393 24 12.458 24 10.314" />
             </svg>
           </div>
-        </a>
-      </div>
-    </section>
+
+          {/* Content */}
+          <div>
+            <p className="text-sm md:text-base text-gray-700 font-medium">
+              新着イベントをLINEでお届け
+            </p>
+            <p className="text-xs text-gray-500 hidden sm:block">
+              友だち追加で通知を受け取る
+            </p>
+          </div>
+        </div>
+
+        {/* Arrow */}
+        <div className="flex-shrink-0 text-gray-400 group-hover:text-[#06C755] transition-colors">
+          <svg
+            className="w-5 h-5 group-hover:translate-x-0.5 transition-transform"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M9 5l7 7-7 7"
+            />
+          </svg>
+        </div>
+      </a>
+    </div>
   );
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -131,26 +131,6 @@ export default async function Page({
 
   const hasPickupEvents = todayEvents.length > 0 || within3DaysEvents.length > 0 || within1WeekEvents.length > 0;
 
-  // Get latest update time per source
-  const sourceLatestUpdate = sources.reduce((acc, s) => {
-    const sourceEvents = events.filter(e => e.sourceId === s.id);
-    if (sourceEvents.length > 0) {
-      acc[s.id] = sourceEvents.reduce(
-        (latest, e) => e.createdAt > latest ? e.createdAt : latest,
-        sourceEvents[0]!.createdAt
-      );
-    }
-    return acc;
-  }, {} as Record<string, Date>);
-
-  // Format update time using JST
-  const formatUpdateTime = (date: Date) => formatDateTimeJST(date);
-
-  // Get overall latest update
-  const latestUpdateTime = Object.values(sourceLatestUpdate).length > 0
-    ? Object.values(sourceLatestUpdate).reduce((a, b) => a > b ? a : b)
-    : null;
-
   // Get event counts per source (from all events, not filtered)
   // Remove duplicates from all events first for accurate counts
   const allUniqueEvents = removeDuplicates(
@@ -169,6 +149,26 @@ export default async function Page({
     acc[s.id] = allEvents.filter(e => e.sourceId === s.id).length;
     return acc;
   }, {} as Record<string, number>);
+
+  // Get latest update time per source (from all events, not filtered)
+  const sourceLatestUpdate = sources.reduce((acc, s) => {
+    const sourceEvents = allEvents.filter(e => e.sourceId === s.id);
+    if (sourceEvents.length > 0) {
+      acc[s.id] = sourceEvents.reduce(
+        (latest, e) => e.createdAt > latest ? e.createdAt : latest,
+        sourceEvents[0]!.createdAt
+      );
+    }
+    return acc;
+  }, {} as Record<string, Date>);
+
+  // Format update time using JST
+  const formatUpdateTime = (date: Date) => formatDateTimeJST(date);
+
+  // Get overall latest update
+  const latestUpdateTime = Object.values(sourceLatestUpdate).length > 0
+    ? Object.values(sourceLatestUpdate).reduce((a, b) => a > b ? a : b)
+    : null;
 
   return (
     <main className="min-h-screen bg-[#fbfbfd] overflow-x-hidden">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { SourceTabs } from "./components/SourceTabs";
 import { SearchForm } from "./components/SearchForm";
 import { PickupCard } from "./components/PickupCard";
 import { PickupCarousel } from "./components/PickupCarousel";
+import { LineBotBanner, LineBotFooterLink } from "./components/LineBotBanner";
 import { getStartOfTodayJST, getDaysFromTodayJST, formatDateTimeJST } from "@/lib/date-utils";
 import { removeDuplicates } from "@/server/utils/duplicateDetector";
 
@@ -252,6 +253,9 @@ export default async function Page({
         </div>
       </section>
 
+      {/* LINE Bot Banner - Hero position */}
+      {!source && !q && <LineBotBanner />}
+
       {/* Pickup Sections - Categorized by time */}
       {hasPickupEvents && !source && !q && (
         <section className="py-6 md:py-10 bg-gradient-to-b from-[#fbfbfd] to-white space-y-6 md:space-y-8">
@@ -399,20 +403,23 @@ export default async function Page({
               </div>
             </div>
 
-            {/* Sources - wrap on mobile */}
-            <div className="flex flex-wrap justify-center gap-1.5 md:gap-2">
-              {sources.map((s) => {
-                const config = SOURCE_CONFIG[s.id];
-                return (
-                  <span
-                    key={s.id}
-                    className={`inline-flex items-center gap-1 px-2 py-1 md:px-3 md:py-1.5 rounded-full text-xs md:text-sm ${config?.bgColor || 'bg-gray-100'} ${config?.color || 'text-gray-600'}`}
-                  >
-                    <span>{config?.emoji || '📅'}</span>
-                    <span className="hidden sm:inline">{config?.label || s.name || s.id}</span>
-                  </span>
-                );
-              })}
+            {/* LINE Bot Link + Sources */}
+            <div className="flex flex-col items-center gap-3 md:gap-4">
+              <LineBotFooterLink />
+              <div className="flex flex-wrap justify-center gap-1.5 md:gap-2">
+                {sources.map((s) => {
+                  const config = SOURCE_CONFIG[s.id];
+                  return (
+                    <span
+                      key={s.id}
+                      className={`inline-flex items-center gap-1 px-2 py-1 md:px-3 md:py-1.5 rounded-full text-xs md:text-sm ${config?.bgColor || 'bg-gray-100'} ${config?.color || 'text-gray-600'}`}
+                    >
+                      <span>{config?.emoji || '📅'}</span>
+                      <span className="hidden sm:inline">{config?.label || s.name || s.id}</span>
+                    </span>
+                  );
+                })}
+              </div>
             </div>
           </div>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -250,11 +250,11 @@ export default async function Page({
           <div className="max-w-2xl mx-auto mt-6 md:mt-10">
             <SearchForm defaultValue={q} />
           </div>
+
+          {/* LINE Bot Banner - inside hero for better visibility on mobile */}
+          {!source && !q && <LineBotBanner />}
         </div>
       </section>
-
-      {/* LINE Bot Banner - Hero position */}
-      {!source && !q && <LineBotBanner />}
 
       {/* Pickup Sections - Categorized by time */}
       {hasPickupEvents && !source && !q && (

--- a/src/server/services/crawlerService.ts
+++ b/src/server/services/crawlerService.ts
@@ -143,12 +143,14 @@ export function formatCrawlerResultsForLine(
     displayEvents.forEach((event, index) => {
       const sourceName = getSourceDisplayName(event.sourceId);
       lines.push(`${index + 1}. [${sourceName}] ${event.title}`);
-      lines.push(`   ${event.url}\n`);
+      // URLは独立した行に配置（先頭に空白なし）
+      lines.push(event.url);
+      lines.push("");
     });
 
     if (newEvents.length > 3) {
       lines.push(`他${newEvents.length - 3}件の新着イベントがあります。`);
-      lines.push("詳しくはこちら:");
+      lines.push("詳しくはこちら↓");
       lines.push(EVENTS_PAGE_URL);
     }
   }

--- a/src/server/services/eventQueryService.ts
+++ b/src/server/services/eventQueryService.ts
@@ -207,12 +207,14 @@ export function formatEventsForLine(
       ? `${event.eventDate.getMonth() + 1}/${event.eventDate.getDate()}`
       : "日付未定";
     lines.push(`${index + 1}. [${dateStr}] ${event.title}`);
-    lines.push(`   ${event.url}\n`);
+    // URLは独立した行に配置（先頭に空白なし）
+    lines.push(event.url);
+    lines.push("");
   });
 
   if (events.length === 5) {
     lines.push("※表示は最大5件です。");
-    lines.push("詳しくはこちら:");
+    lines.push("詳しくはこちら↓");
     lines.push(EVENTS_PAGE_URL);
   }
 
@@ -237,11 +239,13 @@ export function formatRecentEventsForLine(
       : "日程未定";
     const sourceEmoji = event.sourceName.includes("ビール女子") ? "🍺" : "🍷";
     lines.push(`${index + 1}. ${sourceEmoji} [${dateStr}] ${event.title}`);
-    lines.push(`   ${event.url}\n`);
+    // URLは独立した行に配置（先頭に空白なし）
+    lines.push(event.url);
+    lines.push("");
   });
 
   lines.push("━━━━━━━━━━━━━━━━━━━━");
-  lines.push("📱 すべてのイベントを見る:");
+  lines.push("📱 すべてのイベントを見る↓");
   lines.push(EVENTS_PAGE_URL);
 
   return lines.join("\n");


### PR DESCRIPTION
## Summary
- LINE公式アカウント(@472staqy)への友だち追加誘導バナーを追加
- ヒーローセクション下に目立つバナーを配置
- フッターにもコンパクトなLINEリンクを追加
- モバイル対応のレスポンシブデザイン

## Changes
- `LineBotBanner.tsx`: 新規コンポーネント（バナー + フッターリンク）
- `page.tsx`: バナーとフッターリンクを配置

## Test plan
- [ ] ホームページでLINEバナーが表示される
- [ ] バナークリックでLINE友だち追加ページが開く
- [ ] フッターのLINEリンクが機能する
- [ ] モバイル表示でも正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)