### PR TITLE
feat: 新着タブを追加

### DIFF
--- a/src/app/components/SourceTabs.tsx
+++ b/src/app/components/SourceTabs.tsx
@@ -20,11 +20,12 @@ interface SourceTabsProps {
   sourceCounts: Record<string, number>;
   currentSource: string;
   sourceConfig: Record<string, SourceConfig>;
+  newArrivalsCount?: number;
 }
 
 const SCROLL_STORAGE_KEY = 'source-tabs-scroll';
 
-export function SourceTabs({ sources, sourceCounts, currentSource, sourceConfig }: SourceTabsProps) {
+export function SourceTabs({ sources, sourceCounts, currentSource, sourceConfig, newArrivalsCount = 0 }: SourceTabsProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -91,6 +92,26 @@ export function SourceTabs({ sources, sourceCounts, currentSource, sourceConfig 
               {totalCount}
             </span>
           </button>
+
+          {/* New arrivals */}
+          {newArrivalsCount > 0 && (
+            <button
+              onClick={() => handleSourceChange('new')}
+              className={`group relative inline-flex items-center gap-1.5 md:gap-2 px-3 md:px-5 py-2 md:py-2.5 rounded-full text-xs md:text-sm font-medium transition-all duration-300 whitespace-nowrap ${
+                currentSource === 'new'
+                  ? 'bg-gradient-to-r from-green-500 to-emerald-500 text-white shadow-lg shadow-green-500/25'
+                  : 'bg-white text-gray-600 hover:bg-gray-50 shadow-sm border border-gray-200'
+              }`}
+            >
+              <span className="transition-transform group-hover:scale-110">✨</span>
+              <span>新着</span>
+              <span className={`px-1.5 md:px-2 py-0.5 rounded-full text-[10px] md:text-xs ${
+                currentSource === 'new' ? 'bg-white/20' : 'bg-green-100 text-green-700'
+              }`}>
+                {newArrivalsCount}
+              </span>
+            </button>
+          )}
 
           {/* Individual sources */}
           {sources.map((source) => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -51,6 +51,10 @@ export default async function Page({
   // Use JST for all date comparisons
   const startOfTodayJST = getStartOfTodayJST();
 
+  // New arrivals: events created within last 3 days
+  const threeDaysAgo = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000);
+  const isNewArrivalsFilter = source === 'new';
+
   // Base where clause for upcoming events (without source filter)
   const baseWhere: Prisma.EventWhereInput = {
     OR: [
@@ -65,7 +69,8 @@ export default async function Page({
   // Build filtered where clause for display
   const filteredWhere: Prisma.EventWhereInput = {
     ...baseWhere,
-    ...(source && { sourceId: source }),
+    ...(source && !isNewArrivalsFilter && { sourceId: source }),
+    ...(isNewArrivalsFilter && { createdAt: { gte: threeDaysAgo } }),
     ...(q && { title: { contains: q, mode: 'insensitive' as const } }),
   };
 
@@ -149,6 +154,9 @@ export default async function Page({
     acc[s.id] = allEvents.filter(e => e.sourceId === s.id).length;
     return acc;
   }, {} as Record<string, number>);
+
+  // Count new arrivals (created within last 3 days)
+  const newArrivalsCount = allEvents.filter(e => e.createdAt >= threeDaysAgo).length;
 
   // Get latest update time per source (from all events, not filtered)
   const sourceLatestUpdate = sources.reduce((acc, s) => {
@@ -344,6 +352,7 @@ export default async function Page({
           sourceCounts={sourceCounts}
           currentSource={source}
           sourceConfig={SOURCE_CONFIG}
+          newArrivalsCount={newArrivalsCount}
         />
 
         {/* Events Grid */}


### PR DESCRIPTION
## Summary
- 直近3日以内に追加されたイベントを絞り込める「新着」タブを追加
- 新着イベントがある場合のみタブが表示される
- グリーンのグラデーションで新着を強調

## 動作
- `?source=new` でフィルタリング
- 「すべて」タブと各ソースタブの間に表示

## Test plan
- [ ] 新着イベントがある場合、タブが表示されることを確認
- [ ] 新着タブクリックで3日以内のイベントのみ表示されることを確認
- [ ] 新着イベントがない場合はタブが非表示になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)