### PR TITLE
fix: Cronジョブの新着通知に短縮URLを使用

### DIFF
--- a/src/app/api/cron/sync-events/route.ts
+++ b/src/app/api/cron/sync-events/route.ts
@@ -6,6 +6,7 @@ import { crawlBeerfestival } from "@/server/crawlers/beerfestival";
 import { upsertEventsAndGetNewOnes } from "@/server/services/eventService";
 import { sendLineBroadcast } from "@/server/services/lineService";
 import { EVENTS_PAGE_URL } from "@/server/constants";
+import { getShortEventUrl } from "@/server/services/eventQueryService";
 
 export const dynamic = "force-dynamic";
 
@@ -105,7 +106,7 @@ export async function GET(request: Request) {
 
     if (beergirlResult.newEvents.length) {
       beergirlResult.newEvents.forEach((n) =>
-        allNewMessages.push(`🍺[ビール女子] ${n.title}\n${n.url}`)
+        allNewMessages.push(`🍺[ビール女子] ${n.title}\n${getShortEventUrl(n.id)}`)
       );
     }
 
@@ -124,7 +125,7 @@ export async function GET(request: Request) {
 
     if (alwayslovebeerResult.newEvents.length) {
       alwayslovebeerResult.newEvents.forEach((n) =>
-        allNewMessages.push(`🗓️[全国ビールイベント] ${n.title}\n${n.url}`)
+        allNewMessages.push(`🗓️[全国ビールイベント] ${n.title}\n${getShortEventUrl(n.id)}`)
       );
     }
 
@@ -143,7 +144,7 @@ export async function GET(request: Request) {
 
     if (walkerplusResult.newEvents.length) {
       walkerplusResult.newEvents.forEach((n) =>
-        allNewMessages.push(`🍷[Walkerplus] ${n.title}\n${n.url}`)
+        allNewMessages.push(`🍷[Walkerplus] ${n.title}\n${getShortEventUrl(n.id)}`)
       );
     }
 
@@ -162,7 +163,7 @@ export async function GET(request: Request) {
 
     if (beerfestivalResult.newEvents.length) {
       beerfestivalResult.newEvents.forEach((n) =>
-        allNewMessages.push(`🎪[ビアフェス情報] ${n.title}\n${n.url}`)
+        allNewMessages.push(`🎪[ビアフェス情報] ${n.title}\n${getShortEventUrl(n.id)}`)
       );
     }
 


### PR DESCRIPTION
## Summary
- Cronジョブで新着イベントをLINE通知する際に、元のURLではなく短縮URL（`/api/go?id=xxx`）を使用するように修正
- 長いURLがLINEメッセージで不正になる問題を防止

## 変更内容
- `n.url` → `getShortEventUrl(n.id)` に変更（4箇所）
  - ビール女子
  - 全国ビールイベント
  - Walkerplus
  - ビアフェス情報

## Test plan
- [ ] Cronジョブを手動実行し、LINEメッセージのURLが短縮形式になっていることを確認
- [ ] 短縮URLクリックで正しいイベントページにリダイレクトされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * LINE メッセージで送信されるイベント URL のフォーマットを変更しました。複数のイベント情報ソース（ビール女子、全国ビールイベント、Walkerplus、ビアフェス情報）から取得したイベントの URL 表示を最適化しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->