### PR TITLE
feat: 全LINEイベント配信のFlexカルーセル化

### DIFF
--- a/src/app/api/line/webhook/route.ts
+++ b/src/app/api/line/webhook/route.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/server/db";
 import {
   getThisWeeksEvents,
   getRecentEvents,
+  getEventCardsByIds,
   formatEventsForLine,
   formatRecentEventsForLine,
 } from "@/server/services/eventQueryService";
@@ -11,6 +12,8 @@ import {
   crawlAndGetNewEvents,
   formatCrawlerResultsForLine,
 } from "@/server/services/crawlerService";
+import { buildLineFlexMessage, type LineMessage } from "@/server/services/lineService";
+import { EVENTS_PAGE_URL } from "@/server/constants";
 import crypto from "crypto";
 
 export const dynamic = "force-dynamic";
@@ -52,6 +55,65 @@ async function replyMessage(replyToken: string, text: string) {
   }).catch((error) => {
     console.error("Reply message error:", error);
   });
+}
+
+// Reply with arbitrary LINE messages (e.g. a Flex carousel)
+async function replyWithMessages(replyToken: string, messages: LineMessage[]) {
+  const token = process.env.LINE_CHANNEL_ACCESS_TOKEN;
+  if (!token) {
+    console.error("LINE_CHANNEL_ACCESS_TOKEN not set");
+    return;
+  }
+
+  await fetch("https://api.line.me/v2/bot/message/reply", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ replyToken, messages }),
+  }).catch((error) => {
+    console.error("Reply message error:", error);
+  });
+}
+
+// Push arbitrary LINE messages to a user/group/room
+async function pushMessages(to: string, messages: LineMessage[]) {
+  const token = process.env.LINE_CHANNEL_ACCESS_TOKEN;
+  if (!token) {
+    console.error("LINE_CHANNEL_ACCESS_TOKEN not set");
+    return;
+  }
+
+  await fetch("https://api.line.me/v2/bot/message/push", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ to, messages }),
+  }).catch((error) => {
+    console.error("Push message error:", error);
+  });
+}
+
+// Build the [summary text, optional carousel] messages for 最新情報取得
+async function buildLatestInfoMessages(): Promise<LineMessage[]> {
+  const { newEvents, summary } = await crawlAndGetNewEvents();
+  const summaryText = formatCrawlerResultsForLine(newEvents, summary);
+  const messages: LineMessage[] = [{ type: "text", text: summaryText }];
+
+  if (newEvents.length > 0) {
+    const cards = await getEventCardsByIds(newEvents.map((e) => e.id));
+    if (cards.length > 0) {
+      messages.push(
+        buildLineFlexMessage(cards, EVENTS_PAGE_URL, {
+          altText: `🔄 新着イベントが${cards.length}件あります`,
+        })
+      );
+    }
+  }
+  return messages;
 }
 
 // Parse notification interval from explicit command
@@ -259,38 +321,36 @@ export async function POST(request: Request) {
           console.log("User requested latest info:", userId);
           await replyMessage(event.replyToken, "🔄 最新情報を取得中です...");
 
-          const { newEvents, summary } = await crawlAndGetNewEvents();
-          const message = formatCrawlerResultsForLine(newEvents, summary);
-
           // Send result as push message (can't use reply token twice)
-          const token = process.env.LINE_CHANNEL_ACCESS_TOKEN;
-          if (token) {
-            await fetch("https://api.line.me/v2/bot/message/push", {
-              method: "POST",
-              headers: {
-                "Content-Type": "application/json",
-                Authorization: `Bearer ${token}`,
-              },
-              body: JSON.stringify({
-                to: userId,
-                messages: [{ type: "text", text: message }],
-              }),
-            });
-          }
+          await pushMessages(userId, await buildLatestInfoMessages());
         }
         // 今週のイベント
         else if (/今週.*イベント|イベント.*今週/.test(text)) {
           console.log("User requested this week's events:", userId);
           const events = await getThisWeeksEvents();
-          const message = formatEventsForLine(events);
-          await replyMessage(event.replyToken, message);
+          if (events.length === 0) {
+            await replyMessage(event.replyToken, "今週のイベントが見つかりませんでした。");
+          } else {
+            await replyWithMessages(event.replyToken, [
+              buildLineFlexMessage(events, EVENTS_PAGE_URL, {
+                altText: formatEventsForLine(events),
+              }),
+            ]);
+          }
         }
         // イベント（直近5件表示）
         else if (/^イベント$/i.test(text)) {
           console.log("User requested recent events:", userId);
           const events = await getRecentEvents(5);
-          const message = formatRecentEventsForLine(events);
-          await replyMessage(event.replyToken, message);
+          if (events.length === 0) {
+            await replyMessage(event.replyToken, "現在登録されているイベントがありません。");
+          } else {
+            await replyWithMessages(event.replyToken, [
+              buildLineFlexMessage(events, EVENTS_PAGE_URL, {
+                altText: formatRecentEventsForLine(events),
+              }),
+            ]);
+          }
         }
         // 通知間隔の変更
         else {
@@ -341,38 +401,36 @@ export async function POST(request: Request) {
           console.log("Group requested latest info:", id);
           await replyMessage(event.replyToken, "🔄 最新情報を取得中です...");
 
-          const { newEvents, summary } = await crawlAndGetNewEvents();
-          const message = formatCrawlerResultsForLine(newEvents, summary);
-
           // Send result as push message
-          const token = process.env.LINE_CHANNEL_ACCESS_TOKEN;
-          if (token) {
-            await fetch("https://api.line.me/v2/bot/message/push", {
-              method: "POST",
-              headers: {
-                "Content-Type": "application/json",
-                Authorization: `Bearer ${token}`,
-              },
-              body: JSON.stringify({
-                to: id,
-                messages: [{ type: "text", text: message }],
-              }),
-            });
-          }
+          await pushMessages(id, await buildLatestInfoMessages());
         }
         // 今週のイベント
         else if (/今週.*イベント|イベント.*今週/.test(text)) {
           console.log("Group requested this week's events:", id);
           const events = await getThisWeeksEvents();
-          const message = formatEventsForLine(events);
-          await replyMessage(event.replyToken, message);
+          if (events.length === 0) {
+            await replyMessage(event.replyToken, "今週のイベントが見つかりませんでした。");
+          } else {
+            await replyWithMessages(event.replyToken, [
+              buildLineFlexMessage(events, EVENTS_PAGE_URL, {
+                altText: formatEventsForLine(events),
+              }),
+            ]);
+          }
         }
         // イベント（直近5件表示）
         else if (/^イベント$/i.test(text)) {
           console.log("Group requested recent events:", id);
           const events = await getRecentEvents(5);
-          const message = formatRecentEventsForLine(events);
-          await replyMessage(event.replyToken, message);
+          if (events.length === 0) {
+            await replyMessage(event.replyToken, "現在登録されているイベントがありません。");
+          } else {
+            await replyWithMessages(event.replyToken, [
+              buildLineFlexMessage(events, EVENTS_PAGE_URL, {
+                altText: formatRecentEventsForLine(events),
+              }),
+            ]);
+          }
         }
         // 通知間隔の変更
         else {

--- a/src/server/services/eventQueryService.ts
+++ b/src/server/services/eventQueryService.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@/server/db";
 import { APP_URL, EVENTS_PAGE_URL } from "@/server/constants";
+import type { LineEventCard } from "@/server/services/lineService";
 
 /**
  * Generate short URL for event (used in LINE messages)
@@ -7,6 +8,31 @@ import { APP_URL, EVENTS_PAGE_URL } from "@/server/constants";
  */
 export function getShortEventUrl(eventId: string): string {
   return `${APP_URL}/api/go?id=${eventId}`;
+}
+
+type EventWithSource = {
+  id: string;
+  title: string;
+  url: string;
+  sourceId: string;
+  imageUrl: string | null;
+  eventDate: Date | null;
+  eventEndDate: Date | null;
+  source: { name: string };
+};
+
+/** Map a Prisma event (with source) to the LINE carousel card shape. */
+function toLineEventCard(event: EventWithSource): LineEventCard {
+  return {
+    id: event.id,
+    title: event.title,
+    sourceId: event.sourceId,
+    sourceName: event.source.name,
+    url: event.url,
+    imageUrl: event.imageUrl,
+    eventDate: event.eventDate,
+    eventEndDate: event.eventEndDate,
+  };
 }
 
 /**
@@ -112,9 +138,7 @@ export async function getLatestEvents(
  * Get this week's events (upcoming events within 7 days)
  * Only from Beergirl calendar, sorted by event date, max 5 items
  */
-export async function getThisWeeksEvents(): Promise<
-  Array<{ id: string; title: string; url: string; sourceName: string; eventDate?: Date }>
-> {
+export async function getThisWeeksEvents(): Promise<LineEventCard[]> {
   const now = new Date();
   const startOfToday = new Date(now);
   startOfToday.setHours(0, 0, 0, 0);
@@ -138,13 +162,7 @@ export async function getThisWeeksEvents(): Promise<
     take: 5, // Max 5 events
   });
 
-  return events.map((event) => ({
-    id: event.id,
-    title: event.title,
-    url: event.url,
-    sourceName: event.source.name,
-    eventDate: event.eventDate || undefined,
-  }));
+  return events.map(toLineEventCard);
 }
 
 /**
@@ -152,9 +170,7 @@ export async function getThisWeeksEvents(): Promise<
  */
 export async function getRecentEvents(
   limit: number = 5
-): Promise<
-  Array<{ id: string; title: string; url: string; sourceName: string; eventDate?: Date }>
-> {
+): Promise<LineEventCard[]> {
   const now = new Date();
   const startOfToday = new Date(now);
   startOfToday.setHours(0, 0, 0, 0);
@@ -191,22 +207,34 @@ export async function getRecentEvents(
     take: limit,
   });
 
-  return events.map((event) => ({
-    id: event.id,
-    title: event.title,
-    url: event.url,
-    sourceName: event.source.name,
-    eventDate: event.eventDate || undefined,
-  }));
+  return events.map(toLineEventCard);
+}
+
+/**
+ * Get full carousel cards for a set of event IDs, preserving the given order.
+ * Used by the "最新情報取得" webhook path, where freshly-crawled events are
+ * known only by id and need image/date enrichment for rich cards.
+ */
+export async function getEventCardsByIds(ids: string[]): Promise<LineEventCard[]> {
+  if (ids.length === 0) return [];
+
+  const events = await prisma.event.findMany({
+    where: { id: { in: ids } },
+    include: { source: true },
+  });
+
+  const byId = new Map(events.map((e) => [e.id, e]));
+  return ids
+    .map((id) => byId.get(id))
+    .filter((e): e is NonNullable<typeof e> => e != null)
+    .map(toLineEventCard);
 }
 
 /**
  * Format events as LINE message text
  * Uses short URLs to prevent long URLs from breaking in LINE messages
  */
-export function formatEventsForLine(
-  events: Array<{ id: string; title: string; url: string; sourceName: string; eventDate?: Date }>
-): string {
+export function formatEventsForLine(events: LineEventCard[]): string {
   if (events.length === 0) {
     return "今週のイベントが見つかりませんでした。";
   }
@@ -233,9 +261,7 @@ export function formatEventsForLine(
  * Format recent events for "イベント" command
  * Uses short URLs to prevent long URLs from breaking in LINE messages
  */
-export function formatRecentEventsForLine(
-  events: Array<{ id: string; title: string; url: string; sourceName: string; eventDate?: Date }>
-): string {
+export function formatRecentEventsForLine(events: LineEventCard[]): string {
   if (events.length === 0) {
     return "現在登録されているイベントがありません。";
   }

--- a/src/server/services/lineService.ts
+++ b/src/server/services/lineService.ts
@@ -33,9 +33,24 @@ interface EventForNotification {
 }
 
 // LINE message shapes used by the notification senders
-type LineMessage =
+export type LineMessage =
   | { type: "text"; text: string }
   | { type: "flex"; altText: string; contents: unknown };
+
+/**
+ * Canonical input for a single carousel card. All LINE event deliveries
+ * (cron notifications and webhook replies) build cards from this shape.
+ */
+export interface LineEventCard {
+  id: string;
+  title: string;
+  sourceId: string;
+  sourceName: string;
+  url: string;
+  imageUrl: string | null;
+  eventDate: Date | null;
+  eventEndDate: Date | null;
+}
 
 // Flex carousel constraints
 const MAX_CAROUSEL_BUBBLES = 12; // LINE hard limit
@@ -112,10 +127,15 @@ function isLineFlexImageUrl(imageUrl: string | null): imageUrl is string {
  * Build the carousel altText (shown in the notification banner / talk list
  * and as a fallback on clients that cannot render Flex messages).
  */
-function buildAltText(events: EventForNotification[]): string {
+function buildAltText(events: LineEventCard[]): string {
   const head = `🍺 新着ビールイベントが${events.length}件届きました`;
   const firstTitle = events[0]?.title;
   const text = firstTitle ? `${head}\n・${firstTitle} ほか` : head;
+  return clampAltText(text);
+}
+
+/** Clamp arbitrary altText to LINE's limit. */
+function clampAltText(text: string): string {
   return text.length > MAX_ALT_TEXT_CHARS
     ? text.slice(0, MAX_ALT_TEXT_CHARS - 1) + "…"
     : text;
@@ -125,9 +145,9 @@ function buildAltText(events: EventForNotification[]): string {
  * Build a single event bubble. Image-rich (hero) when imageUrl is a valid
  * HTTPS image, otherwise a text-only card with a thin separator (hybrid).
  */
-function buildEventBubble(event: EventForNotification): unknown {
+function buildEventBubble(event: LineEventCard): unknown {
   const emoji = SOURCE_EMOJIS[event.sourceId] || "📅";
-  const label = SOURCE_LABELS[event.sourceId] || event.source.name;
+  const label = SOURCE_LABELS[event.sourceId] || event.sourceName;
   const detailUrl = getShortEventUrl(event.id);
   const dateStr = formatEventDate(event.eventDate, event.eventEndDate);
   // Only use the hero image when it meets LINE's Flex image requirements
@@ -259,13 +279,30 @@ function buildSeeAllBubble(remaining: number, overflowUrl: string): unknown {
   };
 }
 
+/** Map a DB notification event to the canonical card shape. */
+function toLineEventCard(event: EventForNotification): LineEventCard {
+  return {
+    id: event.id,
+    title: event.title,
+    sourceId: event.sourceId,
+    sourceName: event.source.name,
+    url: event.url,
+    imageUrl: event.imageUrl,
+    eventDate: event.eventDate,
+    eventEndDate: event.eventEndDate,
+  };
+}
+
 /**
  * Build a LINE Flex carousel message from events (horizontal swipe).
  * Shows up to MAX_EVENT_CARDS event cards plus a trailing "see all" card.
+ * Pass `altText` to override the default notification-preview text
+ * (used by webhook replies such as 今週のイベント / イベント).
  */
-function buildLineFlexMessage(
-  events: EventForNotification[],
-  overflowUrl: string
+export function buildLineFlexMessage(
+  events: LineEventCard[],
+  overflowUrl: string,
+  options?: { altText?: string }
 ): LineMessage {
   const shown = events.slice(0, MAX_EVENT_CARDS);
   const remaining = events.length - shown.length;
@@ -275,7 +312,7 @@ function buildLineFlexMessage(
 
   return {
     type: "flex",
-    altText: buildAltText(events),
+    altText: options?.altText ? clampAltText(options.altText) : buildAltText(events),
     contents: { type: "carousel", contents: bubbles },
   };
 }
@@ -379,7 +416,7 @@ export async function sendLineNotifications(): Promise<{
     const newestEventCreatedAt = events[0]!.createdAt;
 
     maxEventsNotified = Math.max(maxEventsNotified, events.length);
-    const message = buildLineFlexMessage(events, EVENTS_PAGE_URL);
+    const message = buildLineFlexMessage(events.map(toLineEventCard), EVENTS_PAGE_URL);
     const userIds = subs.map((s) => s.userId);
 
     console.log(`Sending ${events.length} events to ${userIds.length} users (lastNotifiedAt=${lastNotifiedAt?.toISOString() ?? "null"})`);
@@ -426,7 +463,7 @@ export async function sendLineNotifications(): Promise<{
     const newestEventCreatedAt = events[0]!.createdAt;
 
     maxEventsNotified = Math.max(maxEventsNotified, events.length);
-    const message = buildLineFlexMessage(events, EVENTS_PAGE_URL);
+    const message = buildLineFlexMessage(events.map(toLineEventCard), EVENTS_PAGE_URL);
 
     console.log(`Sending ${events.length} events to ${group.type} ${group.id}`);
 


### PR DESCRIPTION
## Summary
cron通知に続き、**残りのLINEイベント配信（Webhook応答）もすべてFlexカルーセル（横スワイプ）に統一**しました。これでイベント内容を返す全経路がリッチ表示になります。

## Changes
- 「今週のイベント」/「イベント（直近5件）」の応答をカルーセル化（reply）
- 「最新情報取得」を **集計テキスト + 新着イベントのカルーセル** の2通に（push）
- カルーセル生成を再利用可能な `buildLineFlexMessage`（export）にリファクタ。共通カード型 `LineEventCard` を導入し、`altText` を差し替え可能に
- `eventQueryService` の `getThisWeeksEvents`/`getRecentEvents` を `LineEventCard`（`sourceId`/`imageUrl`/`eventEndDate` 追加）で返却
- 新規クロール結果（id のみ）を画像・日付付きカードに復元する `getEventCardsByIds` を追加
- 一覧が空のときはプレーンテキストの案内にフォールバック

### スコープ外（テキストのまま）
- ようこそ/ヘルプ、通知間隔の設定確認、停止/再開などの操作通知（イベント内容ではないためカルーセル化の利点が薄い）

## Test Plan
- [ ] CI（Vercelビルド等）がパス
- [ ] `npx tsc --noEmit` 通過（確認済み）
- [ ] 「イベント」「今週のイベント」でカルーセルが返る
- [ ] 「最新情報取得」で集計＋カルーセルが届く
- [ ] イベント0件時にテキスト案内へフォールバック
- [ ] 画像なし/壊れURLのイベントがテキストカードに収まる

🤖 Generated with [Claude Code](https://claude.com/claude-code)