### PR TITLE
feat: LINE配信を関東近郊のイベントのみに限定

### DIFF
--- a/src/app/api/line/webhook/route.ts
+++ b/src/app/api/line/webhook/route.ts
@@ -13,6 +13,7 @@ import {
   formatCrawlerResultsForLine,
 } from "@/server/services/crawlerService";
 import { buildLineFlexMessage, type LineMessage } from "@/server/services/lineService";
+import { filterDeliverableByRegion } from "@/server/utils/regionFilter";
 import { EVENTS_PAGE_URL } from "@/server/constants";
 import crypto from "crypto";
 
@@ -100,11 +101,13 @@ async function pushMessages(to: string, messages: LineMessage[]) {
 // Build the [summary text, optional carousel] messages for 最新情報取得
 async function buildLatestInfoMessages(): Promise<LineMessage[]> {
   const { newEvents, summary } = await crawlAndGetNewEvents();
-  const summaryText = formatCrawlerResultsForLine(newEvents, summary);
+  // Deliver only Kanto-area (or region-unknown) events over LINE.
+  const deliverable = filterDeliverableByRegion(newEvents);
+  const summaryText = formatCrawlerResultsForLine(deliverable, summary);
   const messages: LineMessage[] = [{ type: "text", text: summaryText }];
 
-  if (newEvents.length > 0) {
-    const cards = await getEventCardsByIds(newEvents.map((e) => e.id));
+  if (deliverable.length > 0) {
+    const cards = await getEventCardsByIds(deliverable.map((e) => e.id));
     if (cards.length > 0) {
       messages.push(
         buildLineFlexMessage(cards, EVENTS_PAGE_URL, {

--- a/src/server/services/eventQueryService.ts
+++ b/src/server/services/eventQueryService.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/server/db";
 import { APP_URL, EVENTS_PAGE_URL } from "@/server/constants";
 import type { LineEventCard } from "@/server/services/lineService";
+import { filterDeliverableByRegion } from "@/server/utils/regionFilter";
 
 /**
  * Generate short URL for event (used in LINE messages)
@@ -159,10 +160,11 @@ export async function getThisWeeksEvents(): Promise<LineEventCard[]> {
     orderBy: {
       eventDate: "asc", // Sort by event date
     },
-    take: 5, // Max 5 events
+    take: 30, // Over-fetch so the post-region-filter list can still reach 5
   });
 
-  return events.map(toLineEventCard);
+  // LINE delivery: Kanto-area (or region-unknown) events only.
+  return filterDeliverableByRegion(events.map(toLineEventCard)).slice(0, 5);
 }
 
 /**
@@ -204,10 +206,11 @@ export async function getRecentEvents(
         createdAt: "desc",
       },
     ],
-    take: limit,
+    take: Math.max(limit * 6, 30), // Over-fetch for the region filter below
   });
 
-  return events.map(toLineEventCard);
+  // LINE delivery: Kanto-area (or region-unknown) events only.
+  return filterDeliverableByRegion(events.map(toLineEventCard)).slice(0, limit);
 }
 
 /**

--- a/src/server/services/lineService.ts
+++ b/src/server/services/lineService.ts
@@ -2,6 +2,7 @@ import "server-only";
 import { prisma } from "@/server/db";
 import { EVENTS_PAGE_URL } from "@/server/constants";
 import { getShortEventUrl } from "@/server/services/eventQueryService";
+import { isDeliverableRegion } from "@/server/utils/regionFilter";
 
 const LINE_MULTICAST_ENDPOINT = "https://api.line.me/v2/bot/message/multicast";
 const LINE_PUSH_ENDPOINT = "https://api.line.me/v2/bot/message/push";
@@ -332,13 +333,16 @@ async function getEventsForRecipient(
     ? lastNotifiedAt
     : sevenDaysAgo;
 
-  return prisma.event.findMany({
+  const events = await prisma.event.findMany({
     where: {
       createdAt: { gt: createdAfter },
     },
     include: { source: true },
     orderBy: { createdAt: "desc" },
   });
+
+  // Deliver only Kanto-area (or region-unknown) events over LINE.
+  return events.filter((e) => isDeliverableRegion(e.title));
 }
 
 /**

--- a/src/server/utils/regionFilter.ts
+++ b/src/server/utils/regionFilter.ts
@@ -1,0 +1,64 @@
+/**
+ * Region filter for LINE event delivery.
+ *
+ * Events carry no structured location, so the region is inferred from the
+ * title. Policy (per product decision):
+ *  - Keep events detectably in the Kanto area.
+ *  - Keep events with NO detectable region (lenient — don't drop unknowns).
+ *  - Drop events clearly in another region (Hokkaido, Osaka, Nagoya, ...),
+ *    UNLESS they also mention a Kanto location (e.g. a multi-city tour that
+ *    includes Tokyo).
+ *
+ * This is applied to LINE deliveries only (cron notifications + webhook
+ * event replies). The website event list is intentionally left nationwide.
+ */
+
+// Keywords that mark an event as Kanto. If any is present the event is kept,
+// even when an other-region keyword also appears.
+// NOTE: "東京" must be detected here so that "東京都" is never mistaken for
+// "京都" (Kyoto) by the other-region list below.
+const KANTO_KEYWORDS = [
+  // Prefectures / region
+  "東京", "関東", "首都圏", "神奈川", "埼玉", "千葉", "茨城", "栃木", "群馬",
+  // Major Kanto cities / areas
+  "横浜", "川崎", "みなとみらい", "大宮", "浦和", "渋谷", "新宿", "池袋",
+  "六本木", "銀座", "恵比寿", "代官山", "お台場", "豊洲", "日比谷", "上野",
+  "秋葉原", "品川", "立川", "吉祥寺", "町田", "鎌倉", "横須賀", "柏",
+  "船橋", "高崎", "宇都宮", "つくば",
+];
+
+// Keywords that mark an event as clearly NOT Kanto.
+const OTHER_REGION_KEYWORDS = [
+  // Hokkaido / Tohoku
+  "北海道", "札幌", "青森", "岩手", "宮城", "仙台", "秋田", "山形", "福島",
+  // Chubu / Koshinetsu / Tokai
+  "新潟", "富山", "石川", "金沢", "福井", "山梨", "長野", "岐阜", "静岡",
+  "愛知", "名古屋",
+  // Kansai
+  "三重", "滋賀", "京都", "大阪", "梅田", "難波", "心斎橋", "兵庫", "神戸",
+  "奈良", "和歌山",
+  // Chugoku / Shikoku
+  "鳥取", "島根", "岡山", "広島", "山口", "徳島", "香川", "愛媛", "高知",
+  // Kyushu / Okinawa
+  "福岡", "博多", "佐賀", "長崎", "熊本", "大分", "宮崎", "鹿児島", "沖縄", "那覇",
+];
+
+/**
+ * Whether an event should be delivered over LINE based on its title region.
+ */
+export function isDeliverableRegion(title: string): boolean {
+  if (!title) return true; // no title to judge → keep (lenient)
+  const hasKanto = KANTO_KEYWORDS.some((k) => title.includes(k));
+  if (hasKanto) return true; // Kanto detected → keep
+  const hasOther = OTHER_REGION_KEYWORDS.some((k) => title.includes(k));
+  return !hasOther; // unknown → keep; clearly another region → drop
+}
+
+/**
+ * Filter a list of title-bearing items down to deliverable (Kanto/unknown) ones.
+ */
+export function filterDeliverableByRegion<T extends { title: string }>(
+  items: T[]
+): T[] {
+  return items.filter((item) => isDeliverableRegion(item.title));
+}


### PR DESCRIPTION
## Summary
LINE配信するイベントを**関東近郊のみ**に限定します。イベントに所在地フィールドが無いため、**タイトルから地域を推定**して判定します。

## 判定ポリシー（ユーザー方針どおり）
- 関東と判定できる → 配信
- 地域が判定できない（地名なし） → 配信（緩め、取りこぼし防止）
- 明らかに別地域（北海道・大阪・名古屋 等） → 除外
- 関東と他地域を両方含む（複数都市ツアー等） → 関東を含むので配信

実装は「**他地域キーワードがあり、かつ関東キーワードが無い**ものだけ除外」のブロックリスト方式。

## Changes
- `src/server/utils/regionFilter.ts` を新規追加（`isDeliverableRegion` / `filterDeliverableByRegion`）
- **LINE配信のみ**に適用：
  - cron通知（`getEventsForRecipient`）
  - webhook「今週のイベント」「イベント」（over-fetch→フィルタ→slice で件数を確保）
  - webhook「最新情報取得」（集計テキストとカルーセル両方を関東のみに）
- **Webサイトの一覧は全国のまま**（変更なし）

## 既知の注意点
- `東京都` が `京都` に誤判定されないよう、関東キーワードを優先判定（テスト済み）
- 地名は部分一致のため、稀に人名・店名（例：地名と同じ姓）が混じる可能性あり。実運用で誤判定が出れば辞書を調整可能

## Test Plan
- [x] `npx tsc --noEmit` 通過
- [x] 判定ロジックのエッジケース確認（東京都/京都・大阪・北海道・地名なし・複数都市・全国）
- [ ] CI（Vercelビルド）パス
- [ ] 実機：関東イベントのみ配信される / 大阪・北海道等が除外される

🤖 Generated with [Claude Code](https://claude.com/claude-code)