### PR TITLE
fix: Webサイトで終了済みイベントを非表示（開催中の複数日イベントは表示）

### DIFF
--- a/src/app/components/EventCard.tsx
+++ b/src/app/components/EventCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import { formatDateJST, formatDateRangeJST, getEventStatusJST } from "@/lib/date-utils";
+import { formatDateJST, formatDateRangeJST, getEventStatusJST, getDaysFromTodayJST } from "@/lib/date-utils";
 import { Icon, SourceIcon } from "./Icon";
 
 interface Event {
@@ -38,6 +38,14 @@ export function EventCard({ event, index, sourceConfig }: EventCardProps) {
     ? formatDateRangeJST(event.eventDate, event.eventEndDate)
     : null;
   const status = getEventStatusJST(event.eventDate, event.eventEndDate);
+  // Distinguish an ongoing multi-day event (already started, not yet ended)
+  // from one starting today.
+  const isOngoing =
+    status === "today" &&
+    !!event.eventEndDate &&
+    !!event.eventDate &&
+    getDaysFromTodayJST(event.eventDate) < 0;
+  const todayLabel = isOngoing ? "開催中" : "今日";
 
   const defaultConfig: SourceConfig = {
     icon: 'calendar',
@@ -77,7 +85,7 @@ export function EventCard({ event, index, sourceConfig }: EventCardProps) {
                     ? 'badge-soon'
                     : 'badge-week'
               }`}>
-                {status === 'today' ? '今日' : status === 'soon' ? 'まもなく' : '今週'}
+                {status === 'today' ? todayLabel : status === 'soon' ? 'まもなく' : '今週'}
               </div>
             )}
             {/* Date overlay */}
@@ -132,7 +140,7 @@ export function EventCard({ event, index, sourceConfig }: EventCardProps) {
                       ? 'badge-soon'
                       : 'badge-week'
                 }`}>
-                  {status === 'today' ? '今日' : status === 'soon' ? 'まもなく' : '今週'}
+                  {status === 'today' ? todayLabel : status === 'soon' ? 'まもなく' : '今週'}
                 </div>
               )}
             </div>

--- a/src/app/components/PickupCard.tsx
+++ b/src/app/components/PickupCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import { formatDateJST, formatDateRangeJST } from "@/lib/date-utils";
+import { formatDateJST, formatDateRangeJST, getDaysFromTodayJST } from "@/lib/date-utils";
 import { Icon, SourceIcon } from "./Icon";
 
 interface Event {
@@ -57,6 +57,13 @@ export function PickupCard({ event, sourceConfig, variant = 'week' }: PickupCard
     ? formatDateRangeJST(event.eventDate, event.eventEndDate)
     : null;
   const styles = variantStyles[variant];
+  // Ongoing multi-day event (already started, not yet ended) → "開催中"
+  const isOngoing =
+    variant === "today" &&
+    !!event.eventEndDate &&
+    !!event.eventDate &&
+    getDaysFromTodayJST(event.eventDate) < 0;
+  const badgeLabel = isOngoing ? "開催中" : styles.badge;
 
   const defaultConfig: SourceConfig = {
     icon: 'calendar',
@@ -92,7 +99,7 @@ export function PickupCard({ event, sourceConfig, variant = 'week' }: PickupCard
         {/* Badge */}
         <div className="absolute top-3 right-3 z-10">
           <span className={`badge ${styles.badgeClass}`}>
-            {styles.badge}
+            {badgeLabel}
           </span>
         </div>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,7 @@ import { PickupCard } from "./components/PickupCard";
 import { PickupCarousel } from "./components/PickupCarousel";
 import { LineBotBanner, LineBotFooterLink } from "./components/LineBotBanner";
 import { Icon, SourceIcon } from "./components/Icon";
-import { getStartOfTodayJST, getDaysFromTodayJST, formatDateTimeJST } from "@/lib/date-utils";
+import { getStartOfTodayJST, formatDateTimeJST, getEventStatusJST } from "@/lib/date-utils";
 import { removeDuplicates } from "@/server/utils/duplicateDetector";
 
 export const dynamic = "force-dynamic";
@@ -56,10 +56,15 @@ export default async function Page({
   const threeDaysAgo = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000);
   const isNewArrivalsFilter = source === 'new';
 
-  // Base where clause for upcoming events (without source filter)
+  // Base where clause for upcoming events (without source filter).
+  // Hide events that have already ended, but keep ongoing multi-day events.
   const baseWhere: Prisma.EventWhereInput = {
     OR: [
-      { eventDate: { gte: startOfTodayJST } },
+      // 複数日イベント: 終了日が今日以降＝開催中／未来なら表示（終了済みは非表示）
+      { eventEndDate: { gte: startOfTodayJST } },
+      // 単日イベント: 終了日が無く、開始日が今日以降
+      { eventEndDate: null, eventDate: { gte: startOfTodayJST } },
+      // 日付未取得イベント: 直近14日以内に取得したもののみ
       {
         eventDate: null,
         createdAt: { gte: new Date(Date.now() - 14 * 24 * 60 * 60 * 1000) },
@@ -107,33 +112,22 @@ export default async function Page({
 
   const sources = await prisma.source.findMany();
 
-  // Calculate stats using JST-based day differences
-  const thisWeekEvents = events.filter((e) => {
-    if (!e.eventDate) return false;
-    const days = getDaysFromTodayJST(e.eventDate);
-    return days >= 0 && days <= 7;
-  });
+  // Categorize using the multi-day-aware status helper so that ongoing
+  // events (started earlier, not yet ended) are treated as happening now.
+  const todayEvents = events.filter(
+    (e) => getEventStatusJST(e.eventDate, e.eventEndDate) === "today"
+  );
+  const within3DaysEvents = events.filter(
+    (e) => getEventStatusJST(e.eventDate, e.eventEndDate) === "soon"
+  );
+  const within1WeekEvents = events.filter(
+    (e) => getEventStatusJST(e.eventDate, e.eventEndDate) === "upcoming"
+  );
 
-  // Pickup events categorized by time (using JST)
-  // Today's events (days = 0)
-  const todayEvents = events.filter((e) => {
-    if (!e.eventDate) return false;
-    return getDaysFromTodayJST(e.eventDate) === 0;
-  });
-
-  // Within 3 days (days = 1, 2)
-  const within3DaysEvents = events.filter((e) => {
-    if (!e.eventDate) return false;
-    const days = getDaysFromTodayJST(e.eventDate);
-    return days >= 1 && days <= 2;
-  });
-
-  // Within 1 week (days = 3, 4, 5, 6)
-  const within1WeekEvents = events.filter((e) => {
-    if (!e.eventDate) return false;
-    const days = getDaysFromTodayJST(e.eventDate);
-    return days >= 3 && days <= 6;
-  });
+  // "今週開催" stat: happening now or starting within a week.
+  const thisWeekEvents = events.filter(
+    (e) => getEventStatusJST(e.eventDate, e.eventEndDate) !== null
+  );
 
   const hasPickupEvents = todayEvents.length > 0 || within3DaysEvents.length > 0 || within1WeekEvents.length > 0;
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -49,8 +49,16 @@ export default async function Page({
   const source = params?.source ?? "";
   const q = params?.q ?? "";
 
-  // Use JST for all date comparisons
+  // Use JST for all date comparisons.
+  // Timed iCal rows store eventDate/eventEndDate as true UTC instants, so we
+  // compare against the real-UTC instant of JST today's 00:00 (the date-only
+  // JST boundary shifted back by the +9h offset). This keeps date-only events
+  // (stored at UTC midnight) working while preserving events still running in
+  // the early JST hours of today.
   const startOfTodayJST = getStartOfTodayJST();
+  const jstTodayStartUtc = new Date(
+    startOfTodayJST.getTime() - 9 * 60 * 60 * 1000
+  );
 
   // New arrivals: events created within last 3 days
   const threeDaysAgo = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000);
@@ -61,9 +69,9 @@ export default async function Page({
   const baseWhere: Prisma.EventWhereInput = {
     OR: [
       // 複数日イベント: 終了日が今日以降＝開催中／未来なら表示（終了済みは非表示）
-      { eventEndDate: { gte: startOfTodayJST } },
+      { eventEndDate: { gte: jstTodayStartUtc } },
       // 単日イベント: 終了日が無く、開始日が今日以降
-      { eventEndDate: null, eventDate: { gte: startOfTodayJST } },
+      { eventEndDate: null, eventDate: { gte: jstTodayStartUtc } },
       // 日付未取得イベント: 直近14日以内に取得したもののみ
       {
         eventDate: null,


### PR DESCRIPTION
## Summary
Webサイトの過去日イベント表示を是正します。従来は**開始日（eventDate）だけ**でフィルタしていたため、(1) 開始済みだがまだ**開催中の複数日イベント**が消える、(2) 日付未取得イベントは終了済みでも14日間残る、という挙動でした。**終了日基準**に直し、終了したイベントを非表示・開催中/未来のものは表示します。

## Changes
- `page.tsx` の取得条件を終了日対応に変更：
  - 複数日: `eventEndDate >= 今日`（開催中・未来は表示／終了済みは非表示）
  - 単日: 終了日なし＆`eventDate >= 今日`
  - 日付未取得: 直近14日以内のみ
- ピックアップ（今日/まもなく/今週）と「今週開催」カウントを、複数日対応の `getEventStatusJST` 基準に統一（開催中イベントが正しく表示される）
- カードのバッジ：開催中の複数日イベントは「今日」ではなく「**開催中**」と表示

## スコープ
- 「＋保守的なポリッシュ」方針に従い、DQ風デザインは維持。レイアウト・配色の大きな変更はなし。

## 補足（今回スコープ外）
- LINE配信（cron）は `createdAt` 基準で新着を送るため、開催が過ぎたイベントも配信されうる。必要なら同様に終了日基準のガードを追加可能（別PR）。

## Test Plan
- [x] `npx tsc --noEmit` 通過
- [ ] CI（Vercelビルド）パス
- [ ] 終了済みイベントが一覧/ピックアップから消える
- [ ] 開催中の複数日イベントが「開催中」表示で残る

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正・改善**
  * 複数日開催イベントの表示ロジックを更新しました。開始済みで終了前のイベントは「開催中」と表示されるようになります。
  * イベント検索・フィルタリングの判定基準を更新し、終了済みのイベントを適切に除外します。
  * イベントカテゴリ分類（TODAY / 3日以内 / 1週間以内）の判定精度が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->