### PR TITLE
fix: 保存時の重複排除をソース優先度対応に（ビール女子が消える問題）

### DIFF
--- a/src/server/services/eventService.ts
+++ b/src/server/services/eventService.ts
@@ -6,6 +6,19 @@ import { calculateDuplicateScore } from "../utils/duplicateDetector";
 // Threshold for duplicate detection (0.6 = 60% similarity)
 const DUPLICATE_THRESHOLD = 0.6;
 
+// Source priority (lower index = higher priority). Mirrors removeDuplicates()
+// in duplicateDetector so the preferred source "owns" a shared event.
+const SOURCE_PRIORITY = [
+  "beergirl-calendar",
+  "walkerplus-liquor-kanto",
+  "beerfestival-info",
+  "alwayslovebeer-calendar",
+];
+function sourceRank(sourceId: string): number {
+  const i = SOURCE_PRIORITY.indexOf(sourceId);
+  return i === -1 ? 999 : i;
+}
+
 export interface UpsertResult {
   newEvents: Array<{ id: string; title: string; url: string; sourceId: string }>;
   updatedEvents: Array<{ id: string; title: string; url: string; sourceId: string }>;
@@ -34,6 +47,7 @@ export async function upsertEventsAndGetNewOnes(items: CrawledItem[]): Promise<U
       sourceId: true,
       eventDate: true,
       eventEndDate: true,
+      createdAt: true,
     },
   });
 
@@ -87,10 +101,21 @@ export async function upsertEventsAndGetNewOnes(items: CrawledItem[]): Promise<U
     }
 
     // Check for duplicate events from other sources
-    const isDuplicate = checkForDuplicate(item, existingEvents);
-    if (isDuplicate) {
-      skippedDuplicates++;
-      continue;
+    const dupMatch = findDuplicateMatch(item, existingEvents);
+    let createdAtOverride: Date | undefined;
+    if (dupMatch) {
+      if (sourceRank(dupMatch.existing.sourceId) <= sourceRank(item.sourceId)) {
+        // Existing event is from an equal/higher-priority source → skip.
+        skippedDuplicates++;
+        continue;
+      }
+      // Incoming source is preferred (e.g. beergirl over alwayslovebeer):
+      // store it so the preferred source owns the event, but inherit the
+      // existing row's createdAt so subscribers aren't re-notified.
+      createdAtOverride = dupMatch.existing.createdAt;
+      console.log(
+        `Preferred-source duplicate kept: "${item.title}" (${item.sourceId} > ${dupMatch.existing.sourceId})`
+      );
     }
 
     // Create new Event
@@ -103,6 +128,7 @@ export async function upsertEventsAndGetNewOnes(items: CrawledItem[]): Promise<U
         imageUrl: item.imageUrl,
         eventDate: item.eventDate,
         eventEndDate: item.eventEndDate,
+        ...(createdAtOverride ? { createdAt: createdAtOverride } : {}),
       },
     });
 
@@ -114,6 +140,7 @@ export async function upsertEventsAndGetNewOnes(items: CrawledItem[]): Promise<U
       sourceId: item.sourceId,
       eventDate: item.eventDate || null,
       eventEndDate: item.eventEndDate || null,
+      createdAt: createdAtOverride ?? new Date(),
     });
 
     newEvents.push({
@@ -128,20 +155,27 @@ export async function upsertEventsAndGetNewOnes(items: CrawledItem[]): Promise<U
   return { newEvents, updatedEvents, skippedDuplicates, skippedExisting };
 }
 
+type ExistingEvent = {
+  id: string;
+  title: string;
+  url: string;
+  sourceId: string;
+  eventDate: Date | null;
+  eventEndDate: Date | null;
+  createdAt: Date;
+};
+
 /**
- * Check if an item is a duplicate of any existing event
+ * Find the best cross-source duplicate of an item among existing events.
+ * Returns the highest-scoring match (>= threshold) from a different source,
+ * or null. The caller decides whether to skip based on source priority.
  */
-function checkForDuplicate(
+function findDuplicateMatch(
   item: CrawledItem,
-  existingEvents: Array<{
-    id: string;
-    title: string;
-    url: string;
-    sourceId: string;
-    eventDate: Date | null;
-    eventEndDate: Date | null;
-  }>
-): boolean {
+  existingEvents: ExistingEvent[]
+): { existing: ExistingEvent; score: number } | null {
+  let best: { existing: ExistingEvent; score: number } | null = null;
+
   for (const existing of existingEvents) {
     // Skip same source (already handled by ID dedup)
     if (item.sourceId === existing.sourceId) continue;
@@ -161,14 +195,12 @@ function checkForDuplicate(
       }
     );
 
-    if (score >= DUPLICATE_THRESHOLD) {
-      console.log(
-        `Duplicate detected (${(score * 100).toFixed(1)}%): "${item.title}" ≈ "${existing.title}"`
-      );
-      return true;
+    if (score >= DUPLICATE_THRESHOLD && (!best || score > best.score)) {
+      best = { existing, score };
     }
   }
-  return false;
+
+  return best;
 }
 
 /**


### PR DESCRIPTION
## Summary
「ビール女子」タブにイベントが1件しか出ない問題の修正です。原因は**保存時のクロスソース重複排除**で、ビール女子のイベントが全国カレンダー(alwayslovebeer, 約1.7万件)の重複として弾かれ、保存自体されていませんでした。

## 原因
- ビール女子クローラは未来イベントを6件取得できている（SORACHI DAY/上野盆踊り/ひでじ/Swim/甲府/志摩）。
- しかし `eventService` の重複排除は「他ソースに似たものがあれば（優先度を問わず）スキップ」。全国カレンダーが先に登録済みだと、後発のビール女子版が捨てられ、DBには全国版だけが残る。
- 表示側の重複排除は「ビール女子優先」だが、保存段階で消えているため効かない → ビール女子タブは1件に。

## Changes
- 保存時の重複排除を**優先度対応**に変更（`removeDuplicates` と同じ優先順）：
  - 既存の重複相手が**同等以上の優先度**ならスキップ（従来どおり）。
  - 取り込み側が**より優先**（例: ビール女子 > 全国）なら**保存する**（優先ソースがイベントを"所有"）。
- 再保存時は既存行の `createdAt` を引き継ぎ、**LINE購読者へ重複通知が飛ばない**ように。
- 表示側の重複排除はビール女子優先のため、統合ビューは重複なしのまま。

## 反映タイミング
- 毎日のcron（ビール女子は毎回同じ未来イベントを再取得）で**自動的に埋まります**（次回実行後にビール女子タブが復活）。即時反映が必要なら、通知なしのバックフィル実行も可能です。

## Test Plan
- [x] `npx tsc --noEmit` 通過
- [ ] CI（Vercelビルド）パス
- [ ] 次回cron後、ビール女子タブに複数イベントが表示される
- [ ] 同一イベントの重複通知が飛ばない

🤖 Generated with [Claude Code](https://claude.com/claude-code)